### PR TITLE
design : NTButton 작성

### DIFF
--- a/src/component/common/atom/nt-button/index.tsx
+++ b/src/component/common/atom/nt-button/index.tsx
@@ -49,13 +49,13 @@ const DisabledVariants = cva(
 	},
 )
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+export type NTButtonPT = ButtonHTMLAttributes<HTMLButtonElement> &
 	VariantProps<typeof ButtonVariants> & {
 		children?: React.ReactNode
 		icon?: keyof typeof ICON_DATA
 	}
 
-export const NTButton: React.FC<ButtonProps> = ({
+export const NTButton: React.FC<NTButtonPT> = ({
 	variant,
 	size,
 	children,

--- a/src/component/common/atom/nt-button/index.tsx
+++ b/src/component/common/atom/nt-button/index.tsx
@@ -1,6 +1,7 @@
-import { cva, VariantProps } from "class-variance-authority"
-import { ButtonHTMLAttributes } from "react"
-import NTIcon, { ICON_DATA } from "../../nt-icon"
+import { cva, type VariantProps } from "class-variance-authority"
+import type { ButtonHTMLAttributes } from "react"
+
+import NTIcon, { type ICON_DATA } from "../../nt-icon"
 
 const ButtonVariants = cva(
 	"flex items-center justify-center drop-shadow border",

--- a/src/component/common/atom/nt-button/index.tsx
+++ b/src/component/common/atom/nt-button/index.tsx
@@ -1,0 +1,75 @@
+import { cva, VariantProps } from "class-variance-authority"
+import { ButtonHTMLAttributes } from "react"
+import NTIcon, { ICON_DATA } from "../../nt-icon"
+
+const ButtonVariants = cva(
+	"flex items-center justify-center drop-shadow border",
+	{
+		variants: {
+			variant: {
+				primary: "bg-PB100 text-White hover:bg-PB80 active:bg-Gray80",
+				secondary:
+					"bg-BGblue01 text-PB100 hover:bg-BGblue02 active:bg-BGblue01 active:border-PB100 active:border-[1.6px]",
+				tertiary:
+					"bg-white text-PB100 hover:text-PB80 active:bg-PB80 active:text-White",
+			},
+			size: {
+				large: `w-[144px] h-[62px] rounded-[14px] px-[20px] py-[16px] text-Title03`,
+				medium: `w-[127px] h-[56px] rounded-[12px] px-[18px] py-[12px] text-Headline01`,
+				small: `w-[110px] h-[50px] rounded-[11px] px-[14px] py-[12px] text-Body01`,
+			},
+		},
+		defaultVariants: {
+			variant: "primary",
+			size: "medium",
+		},
+	},
+)
+
+const DisabledVariants = cva(
+	"flex items-center justify-center drop-shadow border",
+	{
+		variants: {
+			variant: {
+				primary: "bg-Gray10 text-Gray60 border-Gray20",
+				secondary: "bg-BGblue01 text-PB50",
+				tertiary: "bg-Gray20 text-Gray50",
+			},
+			size: {
+				large: `w-[144px] h-[62px] rounded-[14px] px-[20px] py-[16px] text-Title03`,
+				medium: `w-[127px] h-[56px] rounded-[12px] px-[18px] py-[12px] text-Headline01`,
+				small: `w-[110px] h-[50px] rounded-[11px] px-[14px] py-[12px] text-Body01`,
+			},
+		},
+		defaultVariants: {
+			variant: "primary",
+			size: "medium",
+		},
+	},
+)
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+	VariantProps<typeof ButtonVariants> & {
+		children?: React.ReactNode
+		icon?: keyof typeof ICON_DATA
+	}
+
+export const NTButton: React.FC<ButtonProps> = ({
+	variant,
+	size,
+	children,
+	icon,
+	disabled = true,
+	...props
+}) => {
+	const classes = disabled
+		? DisabledVariants({ variant, size })
+		: ButtonVariants({ variant, size })
+
+	return (
+		<button className={classes} disabled={disabled} {...props}>
+			<span className="mr-[6px] whitespace-nowrap">{children}</span>
+			{icon && <NTIcon icon={icon} className="w-[28px]" />}
+		</button>
+	)
+}

--- a/src/component/common/atom/nt-button/nt-button.stories.tsx
+++ b/src/component/common/atom/nt-button/nt-button.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof NTButton> = {
 		},
 		icon: {
 			control: "inline-radio",
-			options: Object.keys(ICON_DATA),
+			options: [undefined, ...Object.keys(ICON_DATA)],
 		},
 	},
 }

--- a/src/component/common/atom/nt-button/nt-button.stories.tsx
+++ b/src/component/common/atom/nt-button/nt-button.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import { ICON_DATA } from "../../nt-icon"
+
+import { NTButton } from "."
+
+const meta: Meta<typeof NTButton> = {
+	title: "component/common/nt-button",
+	parameters: {
+		layout: "centered",
+	},
+	component: NTButton,
+	argTypes: {
+		variant: {
+			control: "inline-radio",
+			options: ["primary", "secondary", "tertiary"],
+		},
+		size: {
+			control: "inline-radio",
+			options: ["large", "medium", "small"],
+		},
+		disabled: {
+			control: "boolean",
+		},
+		children: {
+			control: "text",
+		},
+		icon: {
+			control: "inline-radio",
+			options: Object.keys(ICON_DATA),
+		},
+	},
+}
+
+export default meta
+
+type Story = StoryObj<typeof NTButton>
+
+export const Primary: Story = {
+	args: {
+		variant: "primary",
+		size: "large",
+		children: "Button",
+		icon: "check",
+	},
+}
+
+export const Secondary: Story = {
+	args: {
+		variant: "secondary",
+		size: "medium",
+		children: "Button",
+		icon: "check",
+	},
+}
+
+export const Tertiary: Story = {
+	args: {
+		variant: "tertiary",
+		size: "small",
+		children: "Button",
+		icon: "check",
+	},
+}

--- a/src/component/common/nt-icon/index.tsx
+++ b/src/component/common/nt-icon/index.tsx
@@ -22,7 +22,7 @@ export default function NTIcon({ className, icon }: NTIconPT) {
 	)
 }
 
-const ICON_DATA = {
+export const ICON_DATA = {
 	expandDownLight: "lets-icons:expand-down-light",
 	expandUpLight: "lets-icons:expand-up-light",
 	expandRightLight: "lets-icons:expand-right-light",

--- a/src/config/tailwind/styles.ts
+++ b/src/config/tailwind/styles.ts
@@ -24,6 +24,7 @@ export const COLORS = {
 	PY60: "#F7FB98",
 	PY50: "#F8FCA9",
 	BGblue01: "#F6FAFC",
+	BGblue02: "#EFFAFF",
 } as const
 
 export const fontWeight = {

--- a/src/config/tailwind/util.ts
+++ b/src/config/tailwind/util.ts
@@ -1,4 +1,26 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs))
+import { extendTailwindMerge } from "tailwind-merge"
+const customTwMerge = extendTailwindMerge({
+	extend: {
+		classGroups: {
+			"font-size": [
+				"text-LargeTitle",
+				"text-Title01",
+				"text-Title02",
+				"text-Title03",
+				"text-Headline01",
+				"text-Headline02",
+				"text-Button",
+				"text-Body01",
+				"text-Body02",
+				"text-Callout",
+				"text-Caption01",
+				"text-Caption02",
+			],
+			animate: ["animate-in", "animate-out", "animate-none"],
+		},
+	},
+})
+export function cn(...args: ClassValue[]) {
+	return customTwMerge(clsx(...args))
+}


### PR DESCRIPTION
## 🔥 Issues


- issue: [NAILCASE-42](https://nailcase.atlassian.net/browse/NAILCASE-42)



<br/>
<br/>

## 🎯 작업 내용

- [🎨 NTButton 컴포넌트 생성](https://github.com/mobi-projects/nail-case-client/commit/65cc0477f721e3b925e3fbc38004f4b6da1b2cd5)
- button 공용 컴포넌트를 제작하였습니다.

- [🐛 EsLint 규칙에 따라 오류 수정](https://github.com/mobi-projects/nail-case-client/commit/2a09db059eabf26effc7cf19521246c0ef756c3f)
- github push 과정에서 EsLint 오류가 있어서 수정했습니다.

- [🎨 NTButton 스토리 작성](https://github.com/mobi-projects/nail-case-client/commit/6a3264007550fbdc24ff5955022a3a8634c89edf)
- button 스토리 작성 및 배포 완료했습니다.

- [⚡️ cn 함수 수정](https://github.com/mobi-projects/nail-case-client/commit/ae94ef38c2c428b628725115e5a616300653b3c4)
- cn 함수가 적용 안되는 문제 해결했습니다.
- 기존 cn 함수는 함수는 ClassValue 타입의 입력값을 받아 clsx로 결합하고, 그 결과를 twMerge를 통해 병합했습니다.
- 수정된 cn 함수는 extendTailwindMerge를 사용하여 twMerge를 확장하였습니다. customTwMerge는 기본 twMerge에 추가적인 클래스 그룹을 포함하도록 설정을 추가했습니다.

### [스토리북 배포링크](https://66588595839cce76dee2be9d-whcwwyhyuk.chromatic.com/)


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-42]: https://nailcase.atlassian.net/browse/NAILCASE-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ