### PR TITLE
design : manager/base/schedule/today

### DIFF
--- a/src/app/(manager)/manager/base/schedule/today/page.tsx
+++ b/src/app/(manager)/manager/base/schedule/today/page.tsx
@@ -1,0 +1,9 @@
+import DayScheDule from "@/component/custom/manager/base/schedule/today/01"
+
+export default function ManagerBaseScheduleToday() {
+	return (
+		<div className="flex items-center justify-center pt-[32px]">
+			<DayScheDule />
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/schedule/today/01/index.tsx
+++ b/src/component/custom/manager/base/schedule/today/01/index.tsx
@@ -38,11 +38,6 @@ type DayScheduleOptionsPT = {
 	optionArr: string[]
 }
 
-type DayScheduleButtonPT = {
-	slot: Slot
-	currentTime: Dayjs
-}
-
 export default function DayScheDule() {
 	const reservation: Slot[] = [
 		{
@@ -246,7 +241,7 @@ function DayScheduleOptions({ optionArr }: DayScheduleOptionsPT) {
 	)
 }
 
-function DayScheduleButton({ slot, currentTime }: DayScheduleButtonPT) {
+function DayScheduleButton({ slot, currentTime }: DayScheduleTimePT) {
 	const startTime = dayjs().hour(slot.firstTime).minute(0)
 	const endTime = dayjs().hour(slot.endTime).minute(0)
 	const isCurrent =

--- a/src/component/custom/manager/base/schedule/today/01/index.tsx
+++ b/src/component/custom/manager/base/schedule/today/01/index.tsx
@@ -1,0 +1,270 @@
+"use client"
+
+import type { Dayjs } from "dayjs"
+import dayjs from "dayjs"
+import React from "react"
+
+import { NTButton } from "@/component/common/atom/nt-button"
+import NTNameBox from "@/component/common/nt-name-box"
+import NTOption from "@/component/common/nt-option"
+import { useOption } from "@/hook/use-component"
+
+type Artist = {
+	name: string
+	optionArr: string[]
+}
+
+type Slot = {
+	firstTime: number
+	endTime: number
+	artistArr: Artist[]
+}
+
+type DayScheduleTimePT = {
+	slot: Slot
+	currentTime: Dayjs
+}
+
+type DayScheduleDashPT = {
+	slot: Slot
+}
+
+type DayScheduleTaskPT = {
+	slot: Slot
+	duration: number
+}
+
+type DayScheduleOptionsPT = {
+	optionArr: string[]
+}
+
+type DayScheduleButtonPT = {
+	slot: Slot
+	currentTime: Dayjs
+}
+
+export default function DayScheDule() {
+	const reservation: Slot[] = [
+		{
+			firstTime: 11,
+			endTime: 13,
+			artistArr: [
+				{
+					name: "모비쌤",
+					optionArr: [
+						"이달의 아트",
+						"동반 2인",
+						"타샵 제거 있음",
+						"1인 연장 필요",
+					],
+				},
+				{
+					name: "비모쌤",
+					optionArr: [
+						"이달의 아트",
+						"동반 2인",
+						"타샵 제거 있음",
+						"1인 연장 필요",
+					],
+				},
+			],
+		},
+		{
+			firstTime: 15,
+			endTime: 16,
+			artistArr: [
+				{
+					name: "모비쌤",
+					optionArr: ["이달의 아트", "동반 2인", "타샵 제거 있음"],
+				},
+			],
+		},
+		{
+			firstTime: 16,
+			endTime: 17,
+			artistArr: [
+				{
+					name: "비모쌤",
+					optionArr: ["이달의 아트", "동반 2인", "타샵 제거 있음"],
+				},
+			],
+		},
+		{
+			firstTime: 17,
+			endTime: 18,
+			artistArr: [
+				{
+					name: "비모쌤",
+					optionArr: ["이달의 아트", "동반 2인", "타샵 제거 있음"],
+				},
+			],
+		},
+		{
+			firstTime: 18,
+			endTime: 19,
+			artistArr: [
+				{
+					name: "모비쌤",
+					optionArr: ["이달의 아트", "동반 2인", "타샵 제거 있음"],
+				},
+			],
+		},
+		{
+			firstTime: 19,
+			endTime: 20,
+			artistArr: [
+				{
+					name: "미지정",
+					optionArr: ["이달의 아트", "동반 2인", "타샵 제거 있음"],
+				},
+			],
+		},
+	]
+
+	const currentTime = dayjs()
+
+	return (
+		<div className="flex h-fit w-full flex-col rounded-[26px] border">
+			<div className="flex flex-col">
+				{reservation.map((slot, index) => (
+					<DayScheduleTime key={index} slot={slot} currentTime={currentTime} />
+				))}
+			</div>
+			<div className="mt-[20px] flex h-[65px] w-full justify-center text-Headline02 text-Gray50">
+				근무 종료
+			</div>
+		</div>
+	)
+}
+
+function DayScheduleTime({ slot, currentTime }: DayScheduleTimePT) {
+	const duration = slot.endTime - slot.firstTime
+	const boxHeight = 120 * duration
+
+	return (
+		<div
+			className="flex w-full items-center border-b-[2px] border-Gray10"
+			style={{ height: `${boxHeight}px` }}
+		>
+			<DayScheduleDash slot={slot} />
+			<DayScheduleTask slot={slot} duration={duration} />
+			<DayScheduleButton slot={slot} currentTime={currentTime} />
+		</div>
+	)
+}
+
+function DayScheduleDash({ slot }: DayScheduleDashPT) {
+	const hours = []
+	for (let i = slot.firstTime; i <= slot.endTime; i++) {
+		hours.push(i)
+		if (i < slot.endTime) {
+			hours.push("dash")
+		}
+	}
+
+	return (
+		<div className="flex w-[75px] flex-col items-center justify-center">
+			{hours.map((item, index) => (
+				<div
+					key={index}
+					className="flex h-full flex-col items-center justify-center"
+				>
+					{item === "dash" ? (
+						<div className="flex w-full flex-1 items-center justify-center">
+							<div className="h-[30px] border-l-2 border-dashed border-Gray30 py-[18px]"></div>
+						</div>
+					) : (
+						<span className="text-Headline02 text-Gray40">{item}</span>
+					)}
+				</div>
+			))}
+		</div>
+	)
+}
+
+function DayScheduleTask({ slot, duration }: DayScheduleTaskPT) {
+	const height = duration === 2 ? 160 : 86
+	const subHeight = duration === 2 ? 132.7 : 56.54
+	const startTime = dayjs().hour(slot.firstTime).minute(0)
+	const period = startTime.format("A") === "AM" ? "오전" : "오후"
+	const formattedFirstTime = startTime.format("h")
+
+	const getBgColor = (artist: string) => {
+		switch (artist) {
+			case "모비쌤":
+				return "BGblue"
+			case "비모쌤":
+				return "PY"
+			case "미지정":
+				return "Gray"
+			default:
+				return "Gray"
+		}
+	}
+
+	return (
+		<div
+			className="flex w-[792px] items-center rounded-[20px] border"
+			style={{ height: `${height}px` }}
+		>
+			<div
+				className="mr-[15px] border-r-[2px] border-Gray20 pl-[20px] pr-[40px]"
+				style={{ height: `${subHeight}px` }}
+			>
+				<div className="text-Headline02 text-Gray90">
+					{period} {formattedFirstTime}시
+				</div>
+				<div className="text-Callout text-Gray40">
+					{slot.endTime - slot.firstTime}시간
+				</div>
+			</div>
+			<div className="mr-[15px] flex flex-col gap-2">
+				{slot.artistArr.map((artist, idx) => (
+					<React.Fragment key={idx}>
+						<div className="flex items-center gap-2">
+							<NTNameBox bgColor={getBgColor(artist.name)}>
+								{artist.name}
+							</NTNameBox>
+							<DayScheduleOptions optionArr={artist.optionArr} />
+						</div>
+						{idx < slot.artistArr.length - 1 && (
+							<div className="my-1 border-t-[2px] border-Gray10"></div>
+						)}
+					</React.Fragment>
+				))}
+			</div>
+		</div>
+	)
+}
+
+function DayScheduleOptions({ optionArr }: DayScheduleOptionsPT) {
+	const { onClickOption, checkedOption } = useOption(optionArr)
+	return (
+		<NTOption
+			optionArr={optionArr}
+			checkedOption={checkedOption}
+			itemsPerRow={4}
+			onClickOption={onClickOption}
+		/>
+	)
+}
+
+function DayScheduleButton({ slot, currentTime }: DayScheduleButtonPT) {
+	const startTime = dayjs().hour(slot.firstTime).minute(0)
+	const endTime = dayjs().hour(slot.endTime).minute(0)
+	const isCurrent =
+		currentTime.isAfter(startTime) && currentTime.isBefore(endTime)
+
+	return (
+		<div className="flex h-full w-[300px] items-center justify-end">
+			{isCurrent ? (
+				<NTButton disabled>시술중</NTButton>
+			) : (
+				<div className="flex gap-2">
+					<NTButton variant="secondary">변경하기</NTButton>
+					<NTButton variant="primary">채팅하기</NTButton>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/schedule/today/01/index.tsx
+++ b/src/component/custom/manager/base/schedule/today/01/index.tsx
@@ -143,8 +143,7 @@ function DayScheduleTime({ slot, currentTime }: DayScheduleTimePT) {
 
 	return (
 		<div
-			className="flex w-full items-center border-b-[2px] border-Gray10"
-			style={{ height: `${boxHeight}px` }}
+			className={`flex w-full items-center border-b-[2px] border-Gray10 h-[${boxHeight}px]`}
 		>
 			<DayScheduleDash slot={slot} />
 			<DayScheduleTask slot={slot} duration={duration} />
@@ -204,12 +203,10 @@ function DayScheduleTask({ slot, duration }: DayScheduleTaskPT) {
 
 	return (
 		<div
-			className="flex w-[792px] items-center rounded-[20px] border"
-			style={{ height: `${height}px` }}
+			className={`flex w-[792px] items-center rounded-[20px] border h-[${height}px]`}
 		>
 			<div
-				className="mr-[15px] border-r-[2px] border-Gray20 pl-[20px] pr-[40px]"
-				style={{ height: `${subHeight}px` }}
+				className={`mr-[15px] border-r-[2px] border-Gray20 pl-[20px] pr-[40px] h-[${subHeight}px]`}
 			>
 				<div className="text-Headline02 text-Gray90">
 					{period} {formattedFirstTime}시

--- a/src/component/custom/manager/base/schedule/today/01/index.tsx
+++ b/src/component/custom/manager/base/schedule/today/01/index.tsx
@@ -124,7 +124,7 @@ export default function DayScheDule() {
 	const currentTime = dayjs()
 
 	return (
-		<div className="flex h-fit w-full flex-col rounded-[26px] border">
+		<div className="flex h-fit w-full flex-col rounded-[26px] border shadow-customGray60">
 			<div className="flex flex-col">
 				{reservation.map((slot, index) => (
 					<DayScheduleTime key={index} slot={slot} currentTime={currentTime} />
@@ -203,7 +203,7 @@ function DayScheduleTask({ slot, duration }: DayScheduleTaskPT) {
 
 	return (
 		<div
-			className={`flex w-[792px] items-center rounded-[20px] border h-[${height}px]`}
+			className={`flex w-[792px] items-center rounded-[20px] border h-[${height}px] shadow-customGray60`}
 		>
 			<div
 				className={`mr-[15px] border-r-[2px] border-Gray20 pl-[20px] pr-[40px] h-[${subHeight}px]`}


### PR DESCRIPTION

## 🔥 Issues

* issue: [NAILCASE-163](https://nailcase.atlassian.net/browse/NAILCASE-163)
sub-issues:
  - [NAILCASE-174](https://nailcase.atlassian.net/browse/NAILCASE-174)
<br/>
<br/>

## 🎯 작업 내용

- [🎨 오늘스케줄 퍼블리싱](https://github.com/mobi-projects/nail-case-client/commit/f079b07b9a1fbad75c644516e28e1825c7ce84bb)
  ## 오늘 스케줄 퍼블리싱 완료했습니다.
  ![image](https://github.com/mobi-projects/nail-case-client/assets/127207625/5fc6ee06-9365-41fa-aec6-330666043c5c)

  ## 참고사항
  ### pr을 올리는 현재 시각이 오후 8시 47분이여서 ui가 위 사진처럼 `시술중` 버튼이 없습니다.
  ### 아래 사진은 오후 7시쯤 캡쳐한 사진입니다. 해당 시간에 스케줄이 있으므로 `시술중` 버튼이 있습니다.
  ![image](https://github.com/mobi-projects/nail-case-client/assets/127207625/30024385-5697-49af-8f94-081f9b7e8b71)
 
  ## 해결필요❗
  ### 아래 사진을 보면 스케줄이 다 끝난 시점에 ui입니다.
  ### 시술중일때는 `시술중` 버튼이 있고 다음 예약일 때는 `변경하기` 및 `채팅하기` 버튼이 있습니다.
  ### 종료된 예약(시술이 완료된) 건에 대해서는 어떤 ui가 적용되면 좋을까요? 
    ![image](https://github.com/mobi-projects/nail-case-client/assets/127207625/5fc6ee06-9365-41fa-aec6-330666043c5c)

# 🎁 [Vecel에서 확인하기](https://nail-case-client-obfd350rt-newtips.vercel.app/manager/base/schedule/today)(Click me)

<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-163]: https://nailcase.atlassian.net/browse/NAILCASE-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAILCASE-174]: https://nailcase.atlassian.net/browse/NAILCASE-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ