### PR TITLE
design : NTModal 재설계

### DIFF
--- a/src/component/common/nt-modal/nt-modal.context.tsx
+++ b/src/component/common/nt-modal/nt-modal.context.tsx
@@ -1,45 +1,70 @@
 "use client"
-import type { ComponentPropsWithoutRef, PropsWithChildren } from "react"
-import { createContext, useContext, useState } from "react"
+
+import type { ComponentProps, PropsWithChildren } from "react"
+import { createContext, useContext, useRef, useState } from "react"
+
+import { cn } from "@/config/tailwind"
 
 import NTModal from "."
 
-type NTModalPT = ComponentPropsWithoutRef<typeof NTModal>
+type NTModalPT = ComponentProps<typeof NTModal>
 
-type ModalContextPT = {
-	onOpen: (props: NTModalPT) => void
-	onClose: VoidFunction
+const ANIMATION_DURATION = 100
+const ANIMATION_STATES = {
+	idle: "scale-75 opacity-0",
+	entered: "scale-100 opacity-100",
+	exited: "scale-50 opacity-0",
+} as const
+
+const initContextValue = {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	onOpenModal: (args: Partial<NTModalPT>) => {},
+	onCloseModal: () => {},
 }
-const ModalContextInit = {
-	onOpen: () => {},
-	onClose: () => {},
+const initModalAttributes: NTModalPT = {
+	size: "small",
+	isX: false,
 }
-const ModalContext = createContext<ModalContextPT>(ModalContextInit)
+
+const ModalContext = createContext(initContextValue)
 export const useModal = () => useContext(ModalContext)
 
 export const ModalProvider = ({ children }: PropsWithChildren) => {
-	const [propsArr, setPropsArr] = useState<NTModalPT[]>([])
-	const onOpen = ({ ...newAttributes }) =>
-		setPropsArr((prev) => {
-			const _prev = [...prev]
-			_prev.push(newAttributes)
-			return _prev
-		})
-	const onClose = () =>
-		setPropsArr((prev) => {
-			const _prev = [...prev]
-			_prev.pop()
-			return _prev
-		})
-
+	const modalRef = useRef<HTMLDialogElement>(null)
+	const [animationClass, setAnimationClass] = useState<string>(
+		ANIMATION_STATES.idle,
+	)
+	const [modalAttributes, setModalAttributes] =
+		useState<NTModalPT>(initModalAttributes)
+	const onOpenModal = (args: Partial<NTModalPT>) => {
+		setTimeout(() => {
+			setAnimationClass(ANIMATION_STATES.entered)
+		}, ANIMATION_DURATION)
+		modalRef.current?.showModal()
+		setModalAttributes((prev) => ({
+			...prev,
+			...args,
+		}))
+	}
+	const onCloseModal = () => {
+		setAnimationClass(ANIMATION_STATES.exited)
+		setTimeout(() => {
+			modalRef.current?.close()
+			setModalAttributes(initModalAttributes)
+		}, ANIMATION_DURATION)
+	}
 	return (
-		<ModalContext.Provider value={{ onOpen, onClose }}>
+		<ModalContext.Provider value={{ onOpenModal, onCloseModal }}>
 			{children}
-			{propsArr.map((attribute, idx) => (
-				<NTModal key={idx} {...attribute} onClose={onClose}>
-					{attribute.children}
-				</NTModal>
-			))}
+			<div className="sca"></div>
+			<NTModal
+				{...{ ...modalAttributes }}
+				ref={modalRef}
+				className={cn(
+					"transition-all duration-100 ease-in-out",
+					animationClass,
+				)}
+			/>
 		</ModalContext.Provider>
 	)
 }

--- a/src/component/common/nt-modal/nt-modal.stories.tsx
+++ b/src/component/common/nt-modal/nt-modal.stories.tsx
@@ -1,133 +1,98 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
 import { NTButton } from "../atom/nt-button"
-import Pagination from "../nt-pagination"
-import NTSearchfield from "../nt-searchfield"
 
 import { ModalProvider, useModal } from "./nt-modal.context"
 
-import NTModal, {
-	NTModalContent,
-	NTModalDivider,
-	NTModalFooter,
-	NTModalHeader,
-} from "."
+import NTModal, { ModalBody, ModalContent, ModalFooter, ModalHeader } from "."
 
 const meta: Meta<typeof NTModal> = {
 	title: "component/common/nt-modal",
+	parameters: {
+		layout: "centered",
+		hideNoControlsWarning: true,
+	},
 	component: NTModal,
+	argTypes: {
+		size: {
+			control: "inline-radio",
+			options: ["small", "large"],
+		},
+		isX: {
+			control: "boolean",
+		},
+	},
+	args: {
+		size: "small",
+		isX: false,
+	},
 	decorators: [
 		(Story) => (
-			<div className="m-0 flex h-dvh w-dvw items-center justify-center bg-red-300 p-0">
+			<div className="h-[90dvh] w-[90dvw]">
 				<ModalProvider>
 					<Story />
 				</ModalProvider>
 			</div>
 		),
 	],
-	argTypes: {
-		size: {
-			control: "inline-radio",
-			options: ["small", "big"],
-		},
-	},
 }
 export default meta
 
 type Story = StoryObj<typeof NTModal>
 
-export const SmallModalOnlyHeader: Story = {
+export const Laboratory: Story = {
 	args: {
-		size: "small",
-		children: <NTModalHeader size="small">Header</NTModalHeader>,
+		isX: true,
 	},
-}
-export const BigModalOnlyHeader: Story = {
-	args: {
-		size: "big",
-		children: (
-			<NTModalHeader size="big" align="left">
-				Header
-			</NTModalHeader>
-		),
-	},
-}
-export const BigModal: Story = {
-	args: {
-		size: "big",
-		children: (
-			<div>
-				<NTModalHeader align="left" size="big">
-					BigModalHeaderNFooter
-				</NTModalHeader>
-				<NTModalContent className="flex flex-col gap-4 py-4">
-					<h2>소제목 1</h2>
-					<div className="rounded-xl border-2 border-Gray20 p-2">
-						모달 내용 1
-					</div>
-					<div className="rounded-xl border-2 border-Gray20 p-2">
-						모달 내용 2
-					</div>
-					<NTModalDivider size="small" />
-					<h2>소제목 2</h2>
-					<div className="rounded-xl border-2 border-Gray20 p-2">
-						모달 내용 3
-					</div>
-					<div className="rounded-xl border-2 border-Gray20 p-2">
-						모달 내용 4
-					</div>
-					<div className="rounded-xl border-2 border-Gray20 p-2">
-						모달 내용 5
-					</div>
 
-					<NTModalDivider size="small" />
+	render: (args) => {
+		const { onOpenModal } = useModal()
 
-					<h2>소제목 3</h2>
-					<input
-						className="h-[50px] w-full rounded-xl border-2 border-Gray20 p-2"
-						placeholder="마음껏 작성해주세요."
-					/>
-				</NTModalContent>
-				<NTModalFooter>
-					<NTButton>Button</NTButton>
-				</NTModalFooter>
+		const onClickButton = () => {
+			onOpenModal({
+				...args,
+				children: <TestModal />,
+			})
+		}
+		return (
+			<div className="flex h-[85dvh] w-[85dvw] flex-col items-center justify-center gap-10 rounded-[26px] bg-BGblue02 drop-shadow-lg">
+				<h1>NTModal 실험장</h1>
+				<p>패널로 조작 해보세요.!</p>
+				<NTButton onClick={onClickButton} flexible="fit">
+					모달 나옵니다
+				</NTButton>
 			</div>
-		),
+		)
 	},
 }
 
-export const ClickToSmallModal = () => {
-	const { onOpen } = useModal()
-
-	const onClick = () => {
-		onOpen({
-			size: "small",
-			children: (
-				<div>
-					<NTModalHeader>Header</NTModalHeader>
-					<NTModalContent className="flex flex-col gap-4 py-4">
-						<NTSearchfield />
-						<NTModalDivider size="small" weight="bold" color="dark" />
-						<div className="rounded-xl border-2 border-Gray20 p-2">
-							모달 내용 1
-						</div>
-						<div className="rounded-xl border-2 border-Gray20 p-2">
-							모달 내용 2
-						</div>
-						<div className="rounded-xl border-2 border-Gray20 p-2">
-							모달 내용 3
-						</div>
-						<div className="rounded-xl border-2 border-Gray20 p-2">
-							모달 내용 4
-						</div>
-
-						<NTModalDivider />
-						<Pagination totPage={1} curPage={1} perPage={1} />
-					</NTModalContent>
-				</div>
-			),
-		})
-	}
-
-	return <button onClick={onClick}>누르기!</button>
+function TestModal() {
+	const { onCloseModal } = useModal()
+	return (
+		<ModalContent className="flex flex-col gap-3">
+			<ModalHeader className="flex flex-col items-center justify-center">
+				<h2>[Modal Header]</h2>
+			</ModalHeader>
+			<ModalBody className="flex flex-col">
+				<h3>[Modal Body]</h3>
+				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
+				<br />
+				<h3>[Modal Body]</h3>
+				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
+				<br />
+				<h3>[Modal Body]</h3>
+				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
+				<br />
+				<h3>[Modal Body]</h3>
+				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
+				<br />
+				<h3>[Modal Body]</h3>
+				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
+			</ModalBody>
+			<ModalFooter className="flex flex-col items-center justify-center">
+				<h2>[Modal Footer]</h2>
+				<NTButton onClick={onCloseModal}>닫기</NTButton>
+			</ModalFooter>
+		</ModalContent>
+	)
 }

--- a/src/component/custom/manager/base/my-shop/layout/01/index.tsx
+++ b/src/component/custom/manager/base/my-shop/layout/01/index.tsx
@@ -1,120 +1,87 @@
 "use client"
+import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
+import { useRef } from "react"
 
-import BannerCarousel from "@/component/common/nt-banner-carousel"
-import NTContent from "@/component/common/nt-content"
+import NTLogo from "@/../public/asset/nt-logo.svg"
 import NTIcon from "@/component/common/nt-icon"
-import { useModal } from "@/component/common/nt-modal/nt-modal.context"
+import NTSearchfield from "@/component/common/nt-searchfield"
 import NTToolbar from "@/component/common/nt-toolbar"
+import { MANAGER_BASE_MYSHOP_HOME } from "@/constant/routing-path"
 import {
-	LABEL_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR,
+	LABEL_LIST_FOR_MANAGER_BASE_TOOLBAR,
 	PATH_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR,
+	PATH_LIST_FOR_MANAGER_BASE_TOOLBAR,
 } from "@/constant/toolbar-list"
-import { useShopInfo } from "@/hook/use-common"
-import { useBanner } from "@/hook/use-component"
-import type { TShopInfo } from "@/type"
 
-import EditIntroduction from "../modal/01"
-
-type BannerItemPT = { shopInfo: TShopInfo }
-
-export default function ManagerMyShopLayout() {
+export default function ManagerBaseHeader() {
 	return (
-		<div className="h-fit w-full">
-			<MyShopBanner />
-			<MyShopToolbar />
-		</div>
-	)
-}
-function MyShopBanner() {
-	const { handleCarousel, carouselIdx } = useBanner()
-	const { shopInfo } = useShopInfo()
-	const { onOpen } = useModal()
-	if (!shopInfo)
-		return <div className="h-[432.47px] w-full">Loading Banner....</div>
-
-	const onClickPencil = () => {
-		onOpen({
-			size: "small",
-			children: <EditIntroduction />,
-		})
-	}
-
-	return (
-		<div className="h-[432.47px] w-full">
-			<BannerCarousel type="manager" handleCarousel={handleCarousel}>
-				<NTContent mode="dark" className="absolute left-[90px] top-10">
-					미리보기
-				</NTContent>
-				<NTContent
-					mode="dark"
-					className="absolute left-[205px] top-10"
-				>{`${carouselIdx + 1}/${shopInfo.srcArr.length}`}</NTContent>
-				<NTIcon
-					icon="setting"
-					className="absolute right-12 top-10 h-6 w-6 text-White"
-				/>
-				<NTIcon
-					icon="pencil"
-					className="absolute right-12 top-[280px] h-6 w-6 text-White"
-					onClick={onClickPencil}
-				/>
-				<BannerHeader shopInfo={shopInfo} />
-				<BannerDesciption shopInfo={shopInfo} />
-			</BannerCarousel>
-		</div>
-	)
-}
-
-function BannerHeader({ shopInfo }: BannerItemPT) {
-	const { specialty, address, shopName } = shopInfo
-	return (
-		<div className="absolute left-[90px] top-[95px]">
-			<p className="text-Callout text-[14px] font-Light text-White">{`${specialty}  |  ${address}`}</p>
-			<h1 className="text-Title01 text-[28px] font-Bold text-White">
-				{shopName}
-			</h1>
-		</div>
-	)
-}
-
-function BannerDesciption({ shopInfo }: BannerItemPT) {
-	const { hashtagArr, overview } = shopInfo
-	return (
-		<div className="absolute left-[90px] top-[280px] z-10">
-			<div className="flex gap-3">
-				{hashtagArr.map((hashtag, idx) => (
-					<p
-						key={idx}
-						className="text-Body01 text-[18px] font-SemiBold text-White"
-					>
-						{hashtag}
-					</p>
-				))}
+		<div className="flex h-fit w-full flex-col gap-[8.5px] pb-[14px] pt-[68px]">
+			<Image src={NTLogo} alt="brand-logo" width={134} height={38} priority />
+			<div className="flex h-fit w-full flex-col gap-[16.5px]">
+				<ManagerLayoutCatalog />
+				<ManagerBaseToolbar />
 			</div>
-			<p className="line-clamp-3 w-[500px] text-Body01 text-[18px] font-Regular text-Gray10">
-				{overview}
-			</p>
 		</div>
 	)
 }
-
-function MyShopToolbar() {
+function ManagerLayoutCatalog() {
+	return (
+		<div className="flex h-[51px] w-full items-center justify-between">
+			<ManagerLayoutPullDown />
+			<ManagerLayoutSearchfield />
+			<ManagerLayoutSubCatalog />
+		</div>
+	)
+}
+function ManagerLayoutPullDown() {
+	return (
+		<div className="h-[45px] w-[134px] bg-Gray10 text-Gray100">pull down</div>
+	)
+}
+function ManagerLayoutSearchfield() {
+	const searchInputRef = useRef<HTMLInputElement>(null)
+	return (
+		<div className="mx-[70px] h-full w-[690px]">
+			<NTSearchfield size="large" ref={searchInputRef} />
+		</div>
+	)
+}
+function ManagerLayoutSubCatalog() {
+	return (
+		<div className="flex w-[236px] items-center justify-end gap-[12px] pr-[21px]">
+			<NTIcon className="text-Gray90" icon="bellLight" />
+			<div className="h-[50px] w-[50px] rounded-full bg-Gray20"></div>
+		</div>
+	)
+}
+function ManagerBaseToolbar() {
 	const pathName = usePathname()
 	const router = useRouter()
-	const focusedIdx = PATH_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR.findIndex(
-		(toolPath) => toolPath === pathName,
+	const focusedIdx = getFocusedIdx(
+		pathName,
+		[...PATH_LIST_FOR_MANAGER_BASE_TOOLBAR],
+		[...PATH_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR],
 	)
 	const onClickTool = (idx: number) =>
-		router.push(PATH_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR[idx])
+		router.push(PATH_LIST_FOR_MANAGER_BASE_TOOLBAR[idx])
 	return (
-		<div className="relative flex h-fit items-center justify-center pt-[20px] text-[18px] font-SemiBold">
+		<div className="flex w-full flex-col">
+			<hr className="absolute left-0 z-[-10] w-full border border-Gray10" />
 			<NTToolbar
-				toolList={[...LABEL_LIST_FOR_MANAGER_BASE_MYSHOP_TOOLBAR]}
+				toolList={[...LABEL_LIST_FOR_MANAGER_BASE_TOOLBAR]}
 				focusedIdx={focusedIdx}
+				position="top"
 				onClickTool={onClickTool}
 			/>
-			<hr className="absolute bottom-[0.25px] -z-10 w-full border bg-Gray20" />
 		</div>
 	)
+}
+const getFocusedIdx = (
+	pathName: string,
+	toolPathArr: string[],
+	subPathArr: string[],
+) => {
+	if (subPathArr.includes(pathName)) pathName = MANAGER_BASE_MYSHOP_HOME
+	return toolPathArr.findIndex((toolPath) => toolPath === pathName)
 }

--- a/src/component/custom/manager/base/my-shop/layout/modal/01/index.tsx
+++ b/src/component/custom/manager/base/my-shop/layout/modal/01/index.tsx
@@ -1,38 +1,35 @@
 import { NTButton } from "@/component/common/atom/nt-button"
 import {
-	NTModalContent,
-	NTModalFooter,
-	NTModalHeader,
+	ModalBody,
+	ModalContent,
+	ModalFooter,
+	ModalHeader,
 } from "@/component/common/nt-modal"
 import { useModal } from "@/component/common/nt-modal/nt-modal.context"
 import NTSearchfield from "@/component/common/nt-searchfield"
 
 export default function EditIntroduction() {
-	const { onClose } = useModal()
-	const onClickSavingButton = () => {
-		onClose()
+	const { onCloseModal } = useModal()
+	const onClickSaving = () => {
+		onCloseModal()
 	}
 	return (
-		<div className="flex h-full w-full flex-col gap-2">
-			<NTModalHeader>소개글</NTModalHeader>
-
-			<NTModalContent className="flex h-fit flex-col gap-[28px]">
+		<ModalContent className="gap-[50px]">
+			<ModalHeader className="flex items-center justify-center">
+				<p className="text-Body01 text-Gray90">소개글</p>
+			</ModalHeader>
+			<ModalBody className="flex flex-col gap-[27px]">
 				<NTSearchfield />
 				<TextArea tags={["#네일맛집", "#주차가능"]} />
-			</NTModalContent>
-
-			<NTModalFooter className="h-fit">
-				<NTButton onClick={onClickSavingButton}>저장하기</NTButton>
-			</NTModalFooter>
-		</div>
+			</ModalBody>
+			<ModalFooter className="flex h-fit w-full items-center justify-center">
+				<NTButton onClick={onClickSaving}>저장하기</NTButton>
+			</ModalFooter>
+		</ModalContent>
 	)
 }
 
-type TextAreaPT = {
-	tags?: string[]
-}
-
-function TextArea({ tags = [] }: TextAreaPT) {
+function TextArea({ tags = [] }: { tags?: string[] }) {
 	return (
 		<div className="relative flex h-[200px] w-full flex-col gap-[10px] rounded-[22px] border-[1.6px] border-Gray30 bg-White p-[20px] pt-[10px] outline-none">
 			<div className="flex h-fit w-full flex-wrap gap-[5px] text-nowrap">
@@ -42,7 +39,7 @@ function TextArea({ tags = [] }: TextAreaPT) {
 					</p>
 				))}
 			</div>
-			<textarea className="h-[70%] w-full resize-none text-[18px] font-Light text-Gray90 focus-visible:outline-none" />
+			<textarea className="scrollbar-custom h-[70%] w-full resize-none text-[18px] font-Light text-Gray90 focus-visible:outline-none" />
 			<TextCounter length={10} />
 		</div>
 	)


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->

* issue: [NAILCASE-107](https://nailcase.atlassian.net/browse/NAILCASE-107)

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

- [🎨 nt-modal 재설계](https://github.com/mobi-projects/nail-case-client/commit/c7929badf6d326bba5514634301b476e70cbe80f)
- [🎨 scroll 이벤트 발생 시, 배경이 움직이는 이슈 수정](https://github.com/mobi-projects/nail-case-client/commit/f739bcf9b1bbca95fbe08d64d086ca27f4c610cb)
- [🎨 재설계 이전 nt-modal 에 대해, 대체 혹은 삭제](https://github.com/mobi-projects/nail-case-client/commit/1fc3d7b1f74cd62e98ddd300ee66e34885a6f216)
- [🎨 mount/unmount 애니메이션 적용](https://github.com/mobi-projects/nail-case-client/commit/cc2f609c82134cb3498879c94a61454c0ea08948)

기존에 사용하던 NTModal 컴포넌트와 관련하여, 몇가지 이슈가 발견되어 수정 및 보완하였습니다. [📕storybook ↗️](https://66588595839cce76dee2be9d-cfhalwujrr.chromatic.com/?path=/story/component-common-nt-modal--laboratory&args=size:large) 

<br/>
<br/>

### 🔥 문제점1 - 모달 이외 영역 scroll

https://github.com/mobi-projects/nail-case-client/assets/50646145/737fad8a-0871-44e8-b3f9-3a48b34df3d5

<br/>

### 🔥문제점2 - size 절대값

<div align="center">

<img width="550" alt="modal size absoulte value" src="https://github.com/mobi-projects/nail-case-client/assets/50646145/b404110c-1721-4ffc-8bc3-6656fc77a3cb">

</div>


> 기존의 경우, 모달영역의 크기값이 절대적인 수치로 작성했습니다.
> 실제로 모니터 높이가 49x.x 보다 작은 경우, 모달 내부의 컨텐츠가 제대로 출력되지 않는 이슈를 확인했습니다.

<br/>
<br/>

### 💫 어떻게 달라졌나?

#### ⓵. `<dialog/>`(Html-Element) 를 사용했습니다.
z-index 를 별도록 부여하지 않아도, 다른 ui 요소보다 앞서 출력합니다. 
열고 닫음의 상태를 전역적으로 확인할 수 있습니다. 
모달이 열려있다면, 그외 컴포넌트는 'overflow-none' 으로 설정하였습니다.

<div align="center">


https://github.com/mobi-projects/nail-case-client/assets/50646145/aa56481c-c901-4611-a504-5b5bab00a890

_👆 스크롤되지 않음을 표현 중.._

</div>

<br/>
<br/>


#### ⓶. 화면 크기 로 인해, 모달 ui 의 어떤 일부분도 가려지지 않습니다.
figma 설계에 따라 modal 높이(dvh) 를 기준으로 가로비율을 설정했습니다.
그럼에도  사용자 화면에 따라, 모달ui 가 온전히 출력되지 못할 수 있기 때문에 min/max 크기를 지정했습니다.
<div align="center">

<img width="619" alt="modal size relative value" src="https://github.com/mobi-projects/nail-case-client/assets/50646145/dce84b0f-7eea-4d14-8ad9-47bc14195b84">

</div>

<br/>
<br/>

#### ⓷. on/off 직전, 직후에 애니메이션을 추가했습니다. 

https://github.com/mobi-projects/nail-case-client/assets/50646145/947aaa4a-056a-44be-948c-f32081477fda


<br/>
<br/>

### 🤷 사용법

```tsx
"use client"

import { useModal } from "@/component/common/nt-modal/nt-modal.context"

export default funciton SomePage(){

  const { onOpenModal } = useModal()
  
  const onClickButton = () => {
	  onOpenModal({
		  size: "small",             // 👈 "small" | "large" (figma 설계에 따릅니다.)
		  isX: ture,                 // 👈 모달 우측 상단에 x 아이콘 (닫기버튼) 을 출력 여부 설정
		  children: <h1>이것이 모달 ui 내부에 나타납니다.</h1>, // 👈 모달 내부에 보여질 컴포넌트 설정 [🏷️ 아래서 추가 설명]
	  })
  }
  return (
            <NTButton onClick={onClickButton} flexible="fit">
		 모달 나옵니다
             </NTButton>
  )
  },
}
```

<br/>
<br/>

[🏷️ 추가 설명]
위의 예시대로 할 경우, 아래와 같이 출력됩니다.

<div align="center">

<img width="301" alt="print modal example" src="https://github.com/mobi-projects/nail-case-client/assets/50646145/abbf92d8-2ed3-4cfa-8abf-994b0b3be9ce">

</div>

<br/>

모달 내부 컨텐츠를 어떻게 구성할지 각자의 판단을 최대한 존중하는 방향으로 만들었습니다.
피그마 설계에 따라, 모달 영역을 마음껏 활용해주세요.

다만 조금 더 편리하게 사용할 수 있도록 유틸리티(?) 컴포넌트를 만들어봤습니다. (사용을 강제하는 게 아닙니다.)
각 컴포넌트 이름과 특성을 작성해두겠습니다. 

<br/>

<div align="center">

|     |                                                                 |
|:------------:|:---------------------------------------------------------------------------:|
| ModalContent | `ModalHeader`, `ModalBody`, `ModalFooter` 의 부모 컴포넌트로써 활용해야합니다. |
| ModalHeader  | 모달의 가장 상단에 위치합니다.                                               |
| ModalBody    | `ModalHeader`, `ModalFooter` 를 제외한 영역을 갖습니다. 내부 컨텐츠가 너무 크다면, 상하 스크롤이 생성됩니다.                  |
| ModalFooter  | 가장 하단에 위치합니다.    

</div>

<br/>

아래의 모달 유틸리티 컴포넌트의 사용 예시입니다.

```tsx
"use client"

import NTModal, { ModalBody, ModalContent, ModalFooter, ModalHeader } from "@/component/common/nt-modal"

import { useModal } from "@/component/common/nt-modal/nt-modal.context"

export default funciton SomePage(){

  const { onOpenModal } = useModal()
  
  const onClickButton = () => {
	  onOpenModal({
		  ...            
		  children: <ModalContent />, // 👈 🌀 적용
	  })
  }
  return (
            <NTButton onClick={onClickButton} flexible="fit">
		 모달 나옵니다
             </NTButton>
  )
  },
}

function ModalContent() { // 👈 🌀 작성
	const { onCloseModal } = useModal()
	return (
		<ModalContent className="flex flex-col gap-3">
			<ModalHeader className="flex flex-col items-center justify-center">
				<h2>[Modal Header]</h2>
			</ModalHeader>
			<ModalBody className="flex flex-col">
				<h3>[Modal Body]</h3>
				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
				<br />
				<h3>[Modal Body]</h3>
				<p>내용이 많으면 스크롤 영역이 생성됩니다..</p>
			</ModalBody>
			<ModalFooter className="flex flex-col items-center justify-center">
				<h2>[Modal Footer]</h2>
				<NTButton onClick={onCloseModal}>닫기</NTButton>
			</ModalFooter>
		</ModalContent>
	)
}

```

결과는 [📕storybook ↗️](https://66588595839cce76dee2be9d-cfhalwujrr.chromatic.com/?path=/story/component-common-nt-modal--laboratory&args=size:large) 에서 확인할 수 있습니다.



<br/>
<br/>

### ➕ 추가로..
- 리엘님이 일전에 만들어 두었던, `scrollbar-custom` 클래스를 프로젝트 전역에 적용했습니다.

<br/>
<br/>


## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-107]: https://nailcase.atlassian.net/browse/NAILCASE-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ