### PR TITLE
feat : 만료된 accessToken으로 api호출시 interceptor 설정

### DIFF
--- a/src/config/axios/instance.utll.ts
+++ b/src/config/axios/instance.utll.ts
@@ -1,0 +1,27 @@
+import type { InternalAxiosRequestConfig } from "axios"
+import axios from "axios"
+
+import { postResquestNewToken } from "@/util/api/auth-controller"
+import { setAuthTokens } from "@/util/common/auth"
+import { isUndefined } from "@/util/common/type-guard"
+
+// import { setTokens } from "./instance"
+
+//**********  401 에러 발생 시 실행 *************//
+export const handleUnauthorized401 = async (
+	config: InternalAxiosRequestConfig | undefined,
+) => {
+	const originalRequest = config
+	if (isUndefined(originalRequest)) return
+	try {
+		// 토큰 refresh요청
+		const response = await postResquestNewToken()
+		// cookie 재설정
+		setAuthTokens(response.data)
+		// 기존 api요청 header에 재발급 받은 accessToken을 담아서 재요청
+		originalRequest.headers.Authorization = `Bearer ${response.data.accessToken}`
+		return axios(originalRequest)
+	} catch (error) {
+		throw error
+	}
+}

--- a/src/type/sign.ts
+++ b/src/type/sign.ts
@@ -7,3 +7,5 @@ export type TSignDataResponse = {
 	accessTokenExpirationTime: number
 	refreshTokenExpirationTime: number
 }
+
+export type TRefreshDataResponse = { accessToken: string; refreshToken: string }

--- a/src/util/api/auth-controller.ts
+++ b/src/util/api/auth-controller.ts
@@ -1,19 +1,36 @@
 import axios from "axios"
+import { getCookie } from "cookies-next"
 
+import { REFRESH_TOKEN } from "@/constant/auth-key"
 import type { TSignType } from "@/type/union-option/sign-type"
 
 /** [GET] 로그인 요청 api 호출 */
 export const getLogin = async (code: string, loginType: TSignType) => {
 	try {
 		const response = await axios.get(
-			`${process.env.NEXT_PUBLIC_BACKEND_APP_DEP}/auth/${loginType}/kakao`,
+			`${process.env.NEXT_PUBLIC_BACKEND_APP}/auth/${loginType}/kakao`,
 			{
 				params: { code },
 			},
 		)
 		return response.data
 	} catch (error) {
-		console.log(error)
 		throw error
 	}
+}
+
+/** [POST] 리프레쉬 토큰 api 호출 */
+export const postResquestNewToken = async () => {
+	const refreshToken = getCookie(REFRESH_TOKEN)
+
+	const response = await axios.post(
+		`${process.env.NEXT_PUBLIC_BACKEND_APP}/auth/refresh`,
+		{},
+		{
+			headers: {
+				"Refresh-Token": `Bearer ${refreshToken}`,
+			},
+		},
+	)
+	return response
 }

--- a/src/util/api/auth-controller.ts
+++ b/src/util/api/auth-controller.ts
@@ -1,6 +1,7 @@
 import axios from "axios"
 import { getCookie } from "cookies-next"
 
+import { axiosInstance } from "@/config/axios"
 import { REFRESH_TOKEN } from "@/constant/auth-key"
 import type { TSignType } from "@/type/union-option/sign-type"
 
@@ -23,8 +24,8 @@ export const getLogin = async (code: string, loginType: TSignType) => {
 export const postResquestNewToken = async () => {
 	const refreshToken = getCookie(REFRESH_TOKEN)
 
-	const response = await axios.post(
-		`${process.env.NEXT_PUBLIC_BACKEND_APP}/auth/refresh`,
+	const response = await axiosInstance().post(
+		"/auth/refresh",
 		{},
 		{
 			headers: {

--- a/src/util/common/auth.ts
+++ b/src/util/common/auth.ts
@@ -1,0 +1,12 @@
+import { setCookie } from "cookies-next"
+
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constant/auth-key"
+import type { TRefreshDataResponse } from "@/type"
+
+/** accessToken, refreshToken cookie에 추가 */
+export const setAuthTokens = (response: TRefreshDataResponse) => {
+	setCookie(ACCESS_TOKEN, response.accessToken)
+	setCookie(REFRESH_TOKEN, response.refreshToken, {
+		maxAge: 86400,
+	})
+}


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-272](https://nailcase.atlassian.net/browse/NAILCASE-272)
<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->
## [setAuthTokens]
- [✨ 토큰관리 함수, type정의](https://github.com/mobi-projects/nail-case-client/commit/18a3491144e99326e95e8ccb94371e6f7f4b4a87)
> 쿠키관련 함수가 재사용될 경우가 많을것 같습니다..! 따라서 common > auth.ts파일로 따로 분리했습니다.

# ⚙[환경변수 설정 변경]  ([👌환경변수 확인하러가기!](https://www.notion.so/1f4678d474c24ef4bb0de90c68e6bafc))
 **중요한 내용이니 꼭 확인해주세요!!**
> 이전에는 NEXT_PUBLIC_BACKEND_APP, NEXT_PUBLIC_BACKEND_APP_DEP 두개의 환경변수가 있엇는데 하나로 통합했습니다.
> 해당 pr이 merge된 이후에는  `NEXT_PUBLIC_BACKEND_APP` 밖에없으니 보안문서에서 확인해주세요!!

## [postResquestNewToken]
- [🎨 postResquestNewToken 함수](https://github.com/mobi-projects/nail-case-client/commit/c2265fde8e8dfc9398acac36c710bd33402aeebd)
> accessToken만료시간 => 1시간 , refreshToken만료시간 ==> 12시간  입니다.
> 따라서 accessToken만료된상태로 사용자가 api호출을 한다면???
>` postResquestNewToken()`를 통해 토큰을 재발급 받습니다.
> 재발급된 토큰은 accessToken , refreshToken 모두 갱신해줍니다..!

## [handleUnauthorized401]
- [🎨 handleUnauthorized401 함수](https://github.com/mobi-projects/nail-case-client/commit/c82566028e833030e77fc2ef73f5b851ead14154)
>  만료된 토큰으로 api호출시  ==> 401에러를 반환합니다. 
> 401에러를 받았을경우 action
> 1. 기존 refreshToken을 사용해서 token재발급 요청을 보냅니다.
> 2. 새로갱신된 accessToken을  기존 api요청 header에 포함시켜  서버로 기존 요청 반복!

## [interceptor 에 적용하기]
- [🎨 interceptor 설정변경](https://github.com/mobi-projects/nail-case-client/commit/ddd7db091b277d34fd7c1548aef2f6d9ed48243a)
> 401에러 반환시 handleUnauthorized401를 실행하는 코드를 interceptor response에 적용시켰습니다.

# [결과 확인하기]
<div align="center">

## [토큰 만료시 api요청]

<img width="320" alt="image" src="https://github.com/user-attachments/assets/db16041e-31c2-4432-9187-93965551699b">

> 토큰이 만료된 상황 = accessToken에 잘못된 값이 담겼을때와 동일합니다.

## [네트워크 창에서 확인]

<img width="509" alt="image" src="https://github.com/user-attachments/assets/c6a7c9b3-346f-4232-b9ab-59e58a69a1e6">

> 예시로 실제 api호출을 보낸 사진입니다.  
> 1.api호출시 실패 . 2. 토큰 재발급api호출  3. refresh성공후 기존 api요청 성공 

## [콘솔에서 확인]

<img width="452" alt="image" src="https://github.com/user-attachments/assets/b325bd91-6f25-4736-b120-09b4fbb79417">

> 1.성공한 첫번째 콘솔은 refresh 요청에 대한 콘솔입니다.
> 2.성공한 두번째 콘솔은 api호출  요청에 대한 콘솔입니다.

</div>

## [추가로,,,]

> 이전에 백엔드팀에 요청실패시 401을 반환해달라고 제가 요청을 드렸었는데 잘못된 요청을 드렸습니다 ㅜㅜ 
> 토큰만료시에만 401을 반환받아야하는데 모두 401을 반환받습니다..
> 이에따라서 현재 설정에서 무한루프에 빠질 case가 존재하는데요... 이부분은 백엔드팀에 재요청 드려서 완료되는대로 수정하겠습니다.!

<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-272]: https://nailcase.atlassian.net/browse/NAILCASE-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ