### PR TITLE
feat : middleware 설정으로 권한여부에 따라 사용자 페이지 접근권한 설정

### DIFF
--- a/src/constant/auth-key.ts
+++ b/src/constant/auth-key.ts
@@ -1,2 +1,3 @@
 export const ACCESS_TOKEN = "accessToken"
 export const REFRESH_TOKEN = "refreshToken"
+export const IS_MANAGER = "isManager"

--- a/src/hook/use-auth-controller.ts
+++ b/src/hook/use-auth-controller.ts
@@ -1,12 +1,11 @@
 import { useMutation } from "@tanstack/react-query"
-import { setCookie } from "cookies-next"
 
-import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constant/auth-key"
 import { COMMON_HOME } from "@/constant/routing-path"
 import type { TSignDataResponse } from "@/type"
 import type { TResponseData } from "@/type/response"
 import type { TSignType } from "@/type/union-option/sign-type"
 import { getLogin } from "@/util/api/auth-controller"
+import { initAuthTokens } from "@/util/common/auth"
 
 type UseGetAuthTokenPT = { code: string; loginType: TSignType }
 
@@ -15,19 +14,7 @@ export const useGetAuthToken = () => {
 		mutationFn: async ({ code, loginType }: UseGetAuthTokenPT) =>
 			await getLogin(code, loginType),
 		onSuccess: async ({ data }: TResponseData<TSignDataResponse, "data">) => {
-			const {
-				accessToken,
-				refreshToken,
-				accessTokenExpirationTime,
-				refreshTokenExpirationTime,
-			} = data
-
-			setCookie(ACCESS_TOKEN, accessToken, {
-				maxAge: accessTokenExpirationTime,
-			})
-			setCookie(REFRESH_TOKEN, refreshToken, {
-				maxAge: refreshTokenExpirationTime,
-			})
+			initAuthTokens(data)
 		},
 		onError: (error) => {
 			alert("로그인 실패")

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
+
+import { ACCESS_TOKEN, IS_MANAGER } from "./constant/auth-key"
+
+export function middleware(request: NextRequest) {
+	const token = request.cookies.get(ACCESS_TOKEN)
+	const isManager = request.cookies.get(IS_MANAGER)?.value === "true"
+	const isAuth = !!token
+
+	// 요청 URL을 확인합니다.
+	const url = request.nextUrl.clone()
+	const pathname = url.pathname
+
+	// '/sign/oauth2/callback/kakao'와 '/sign' 경로는 미들웨어를 건너뜁니다.
+	if (
+		pathname.startsWith("/sign/oauth2/callback/kakao") ||
+		pathname.startsWith("/sign")
+	) {
+		return NextResponse.next()
+	}
+
+	// 사용자가 로그인이 되어 있지만 manager 페이지 접근을 차단
+	if (isAuth && !isManager && pathname.startsWith("/manager")) {
+		console.log("Redirecting to home from manager page")
+		return NextResponse.redirect(new URL("/", request.url))
+	}
+	// 비로그인 상태에서의 /manager 경로 접근 차단
+	if (!isAuth && pathname.startsWith("/manager")) {
+		return NextResponse.redirect(new URL("/", request.url))
+	}
+
+	// 비로그인 상태에서 shopId/숫자 경로는 접근 허용, 그 이후의 서브 경로는 차단
+	if (!isAuth && pathname.match(/^\/shop\/\d+\/(?!$)/)) {
+		return NextResponse.redirect(new URL("/", request.url))
+	}
+
+	// 로그인 상태에서 모든 페이지 접근 허용
+	return NextResponse.next()
+}
+
+// 모든 경로에 적용합니다.
+export const config = {
+	matcher: "/((?!api|_next/static|_next/image|favicon.ico).*)",
+}

--- a/src/type/sign.ts
+++ b/src/type/sign.ts
@@ -3,7 +3,7 @@ export type TSignDataResponse = {
 	refreshToken: string
 	shopIds: null | Array<number>
 	hasShop: boolean
-	userType: "MEMBER" | "MANAGER"
+	role: "MEMBER" | "MANAGER"
 	accessTokenExpirationTime: number
 	refreshTokenExpirationTime: number
 }

--- a/src/util/api/auth-controller.ts
+++ b/src/util/api/auth-controller.ts
@@ -6,7 +6,7 @@ import type { TSignType } from "@/type/union-option/sign-type"
 export const getLogin = async (code: string, loginType: TSignType) => {
 	try {
 		const response = await axios.get(
-			`${process.env.NEXT_PUBLIC_BACKEND_APP_DEP}/auth/${loginType}/kakao`,
+			`${process.env.NEXT_PUBLIC_BACKEND_APP}/auth/${loginType}/kakao`,
 			{
 				params: { code },
 			},

--- a/src/util/common/auth.ts
+++ b/src/util/common/auth.ts
@@ -1,7 +1,7 @@
 import { setCookie } from "cookies-next"
 
 import { ACCESS_TOKEN, IS_MANAGER, REFRESH_TOKEN } from "@/constant/auth-key"
-import type { TSignDataResponse } from "@/type"
+import type { TSignDataResponse, TRefreshDataResponse } from "@/type"
 
 export const initAuthTokens = ({
 	accessToken,
@@ -13,10 +13,6 @@ export const initAuthTokens = ({
 	setCookie(REFRESH_TOKEN, refreshToken, { maxAge: 86400 })
 	setCookie(IS_MANAGER, isManager)
 }
-import { setCookie } from "cookies-next"
-
-import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constant/auth-key"
-import type { TRefreshDataResponse } from "@/type"
 
 /** accessToken, refreshToken cookie에 추가 */
 export const setAuthTokens = (response: TRefreshDataResponse) => {

--- a/src/util/common/auth.ts
+++ b/src/util/common/auth.ts
@@ -1,0 +1,15 @@
+import { setCookie } from "cookies-next"
+
+import { ACCESS_TOKEN, IS_MANAGER, REFRESH_TOKEN } from "@/constant/auth-key"
+import type { TSignDataResponse } from "@/type"
+
+export const initAuthTokens = ({
+	accessToken,
+	role,
+	refreshToken,
+}: TSignDataResponse) => {
+	const isManager = role === "MANAGER"
+	setCookie(ACCESS_TOKEN, accessToken)
+	setCookie(REFRESH_TOKEN, refreshToken, { maxAge: 86400 })
+	setCookie(IS_MANAGER, isManager)
+}


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-309](https://nailcase.atlassian.net/browse/NAILCASE-309)
<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->
# [판매자 or 사용자 check할 변수 role 추가]
- [🏷️ 타입수정, 상수 수정](https://github.com/mobi-projects/nail-case-client/commit/37c37f322a8f423ade05aafeca1994209ecc2615)

> 접근제한기준은 두가지로 나뉩니다.
> 로그인 or 비로그인
> 로그인한사용자라면? =>  사용자 or 판매자
> 판매자인지 사용자인지 특정할 role을 추가하고 로그인시 cookie에 저장해서 판단합니다.

# [initAuthTokens]
- [✨ initAuthTokens 추가](https://github.com/mobi-projects/nail-case-client/commit/95db8b9c66b58b60d48f765b4c0660c3d155294c)

> 첫 로그인시 cookie에 세가지 정보를 저장합니다.
> access-token, refresh-token, isManager (= 사용자인지 판매자인지 여부 boolean으로)

# [사용자 접근제한 case분리]
- [🔧 middleware 추가](https://github.com/mobi-projects/nail-case-client/commit/966766041b38e41755587febc0b51ac963f444c3)

> case 로그인 여부에 따라서
> - 비로그인 사용자라면? ==> /shop/(샵넘버)  & "/" 까지만 접근 가능 그 외 페이지는 불가능

> case 사용자인지 판매자인지 여부에 따라서
> - 로그인한 사용자라면?  ==> /manger 경로로 시작하는 페이지 외에는 접근 가능
> - 로그인한 판매자라면?  ==> 모든 경로에 접근가능

> case 로그인 페이지에 대해서는?
> 로그인 페이지는 middleware의 영향을 받지않고 모두 접근가능하도록 설정

<div align="center">

## [비로그인 접근시]

![bandicam-2024-07-15-05-40-32-948](https://github.com/user-attachments/assets/4e550454-4423-444c-927d-99315eed53bc)

> 비로그인 사용자라면 shop/(샵넘버) 까지는 접근 가능 & 이후 경로는 홈으로 보냅니다.

## [로그인 한 `사용자`]


![bandicam-2024-07-15-05-41-32-659](https://github.com/user-attachments/assets/b3b10436-fbc8-499a-afb9-24d40cfcfe01)

> 로그인한 사용자라면 /mager로 시작하는 경로접근시 홈으로, 사용자 페이지는 모두 접근가능 합니다.

## [로그인 한 `판매자`]

![bandicam-2024-07-15-05-43-45-442](https://github.com/user-attachments/assets/b762656b-1fb8-417a-ab15-8920dc3e6fe1)

## [토큰이 없어지면?]


![bandicam-2024-07-15-05-44-16-554](https://github.com/user-attachments/assets/ccc01581-92a7-4a20-b250-e74959626e6f)

> 토큰이 만료되면 홈으로 보냅니다.

</div>

# [추가로...]

> 현재 권한 없을경우 모두 홈으로 redirection을 시키고있지만 UX를 높이려면 toast를 보여준다던지?
> 혹은 비로그인에서 예약하기버튼 클릭시 로그인페이지로 redirection을 시키던지 
> 잘못된 접근시 따로 페이지를 두고 경고 페이지를 만들어준다던지..
> 이런 설계가 더필요할 것 같습니다. 이런 부분들은 같이 고민해보면 어떨까요?

<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-309]: https://nailcase.atlassian.net/browse/NAILCASE-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ