### PR TITLE
refactor : NTPulldown 재설계 & 판매자 header에 적용

### DIFF
--- a/src/app/(manager)/manager/base/layout.tsx
+++ b/src/app/(manager)/manager/base/layout.tsx
@@ -1,3 +1,4 @@
+import { NTPulldownProvider } from "@/component/common/atom/nt-pulldown"
 import NTToast from "@/component/common/nt-toast"
 import ManagerBaseHeader from "@/component/custom/manager/base/layout/01"
 
@@ -8,8 +9,10 @@ export default function ManagerBaseLayout({
 }>) {
 	return (
 		<div className="w-full pb-[42px]">
-			<ManagerBaseHeader />
-			<NTToast />
+			<NTPulldownProvider>
+				<ManagerBaseHeader />
+				<NTToast />
+			</NTPulldownProvider>
 			{children}
 		</div>
 	)

--- a/src/app/(manager)/manager/base/layout.tsx
+++ b/src/app/(manager)/manager/base/layout.tsx
@@ -8,12 +8,13 @@ export default function ManagerBaseLayout({
 	children: React.ReactNode
 }>) {
 	return (
-		<div className="w-full pb-[42px]">
-			<NTPulldownProvider>
+		<NTPulldownProvider>
+			<div className="w-full pb-[42px]">
 				<ManagerBaseHeader />
 				<NTToast />
-			</NTPulldownProvider>
-			{children}
-		</div>
+
+				{children}
+			</div>
+		</NTPulldownProvider>
 	)
 }

--- a/src/component/common/atom/nt-pulldown/index.tsx
+++ b/src/component/common/atom/nt-pulldown/index.tsx
@@ -1,131 +1,203 @@
 "use client"
+import { cva } from "class-variance-authority"
+import type { HTMLAttributes, ReactNode, RefObject } from "react"
+import { createContext, useContext, useRef, useState } from "react"
 
 import { cn } from "@/config/tailwind"
 
-import NTIcon from "../../nt-icon"
+// Context 타입 정의
+type TNTPulldownContext = {
+	isOpen: boolean
+	clickedIdx: number
+	toggleOpen: () => void
+	selectIdx: (option: number) => void
+	boxRef: RefObject<HTMLDivElement>
+	triggerRef: RefObject<HTMLDivElement>
+}
 
-type NTPulldownPT = {
-	optionArr: Array<string>
-	isOpen: boolean
-	onClickWrapper: VoidFunction
-	onClickTrigger: VoidFunction
-	onClickItems: (idx: number) => void
+// Pulldown의 상태 및 기능을 제공하는 Context 생성
+const NTPulldownContext = createContext<TNTPulldownContext | undefined>(
+	undefined,
+)
+
+// Context를 사용하는 커스텀 훅
+export const useNTPulldown = () => {
+	const context = useContext(NTPulldownContext)
+	if (!context) {
+		throw new Error("useNTPulldown must be used within a NTPulldownProvider")
+	}
+	return context
 }
-type NTPulldownTriggerPT = {
-	isOpen: boolean
-	optionArr: Array<string>
-	clickCallback: VoidFunction
-}
-type NTPulldownItemsPT = {
-	optionArr: Array<string>
-	clickCallback: (option: number) => void
-	isOpen: boolean
-}
-type NTArrowPT = {
-	isOpen: boolean
-	className?: string
-}
+
 /**
- * @description - usePulldown(initialArr) 의 return값들을 props로전달
+ * ------------------------ NTPulldownProvider ------------------------
+ * Pulldown 컴포넌트를 감싸고 상태 및 기능을 Context로 제공합니다.
+ *
+ * @param children - Pulldown 컴포넌트에 포함될 자식 요소들
+ *
  */
-export default function NTPulldown({
-	optionArr,
-	isOpen,
-	onClickItems,
-	onClickTrigger,
-	onClickWrapper,
-}: NTPulldownPT) {
+type NTPulldownProviderPT = {
+	children: ReactNode
+}
+
+export function NTPulldownProvider({ children }: NTPulldownProviderPT) {
+	const [isOpen, setIsOpen] = useState(false)
+	const [clickedIdx, setClickedIdx] = useState(0)
+	const boxRef = useRef<HTMLDivElement>(null)
+	const triggerRef = useRef<HTMLDivElement>(null)
+
+	const toggleOpen = () => setIsOpen(!isOpen)
+	const selectIdx = (option: number) => {
+		setClickedIdx(option)
+		setIsOpen(false)
+	}
+
+	/**
+	 * Blur 이벤트를 처리하여, Pulldown이 열린 상태에서 포커스가
+	 * Pulldown 외부로 이동하면 닫히게 합니다.
+	 *
+	 * @param event - FocusEvent 객체
+	 */
+	const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+		if (
+			boxRef.current &&
+			!boxRef.current.contains(event.relatedTarget as Node) &&
+			triggerRef.current &&
+			!triggerRef.current.contains(event.relatedTarget as Node)
+		) {
+			setIsOpen(false)
+		}
+	}
+
+	return (
+		<NTPulldownContext.Provider
+			value={{ isOpen, clickedIdx, toggleOpen, selectIdx, boxRef, triggerRef }}
+		>
+			<div className="h-fit w-full" onBlur={handleBlur} tabIndex={-1}>
+				{children}
+			</div>
+		</NTPulldownContext.Provider>
+	)
+}
+
+/**
+ * ------------------------ NTPulldownTrigger ------------------------
+ * Pulldown을 열고 닫는 트리거 역할을 하는 컴포넌트입니다.
+ *
+ * @param children - 트리거로 사용할 내용
+ * @param className - 추가적인 CSS 클래스
+ *
+ */
+type NTPulldownTriggerPT = { children: ReactNode; className?: string }
+
+export function NTPulldownTrigger({
+	children,
+	className,
+}: NTPulldownTriggerPT) {
+	const { toggleOpen, triggerRef } = useNTPulldown()
 	return (
 		<div
-			className={cn(
-				"w-[151px] cursor-pointer border-[0.5px] border-Gray40 hover:border-transparent hover:bg-Gray10",
-				isOpen
-					? "rounded-[14px] hover:border-[0.5px] hover:border-Gray40 hover:bg-transparent"
-					: "rounded-[35px]",
-			)}
-			onBlur={onClickWrapper}
+			ref={triggerRef}
+			tabIndex={0}
+			onClick={toggleOpen}
+			className={cn("cursor-pointer", className)}
 		>
-			<NTPulldownTrigger
-				isOpen={isOpen}
-				clickCallback={onClickTrigger}
-				optionArr={optionArr}
-			/>
-			{isOpen && (
-				<NTPulldownItems
-					optionArr={optionArr}
-					clickCallback={onClickItems}
-					isOpen={isOpen}
-				/>
-			)}
+			{children}
 		</div>
 	)
 }
 
-function NTArrow({ isOpen, className }: NTArrowPT) {
-	const arrowDirection = isOpen ? "check" : "expandDownLight"
-	return (
-		<NTIcon
-			icon={arrowDirection}
-			className={cn("h-5 w-5 text-Gray70", isOpen && "text-Gray30", className)}
-		/>
-	)
+/**
+ * ------------------------ NTPulldownContent ------------------------
+ * Pulldown의 내용을 표시하는 컴포넌트입니다.
+ * `isOpen` 상태에 따라 내용을 보여주거나 숨깁니다. `position` prop을 통해 내용의 위치를 조절할 수 있습니다.
+ *
+ * @param children - Pulldown의 항목들
+ * @param className - 추가적인 CSS 클래스
+ * @param position - 내용의 위치를 조절 (center, left, right)
+ *
+ */
+type NTPulldownContentPT = {
+	children: ReactNode
+	className?: string
+	position?: "center" | "left" | "right"
 }
 
-function NTPulldownTrigger({
-	isOpen,
-	optionArr,
-	clickCallback,
-}: NTPulldownTriggerPT) {
+const positionVariants = cva(
+	"absolute top-full z-10 mt-2 w-[13rem] overflow-hidden bg-white shadow-lg transition-all duration-500 ease-in-out",
+	{
+		variants: {
+			position: {
+				center: "left-1/2 -translate-x-1/2 transform",
+				left: "left-0",
+				right: "right-0",
+			},
+		},
+		defaultVariants: { position: "center" },
+	},
+)
+
+export function NTPulldownContent({
+	children,
+	className,
+	position,
+}: NTPulldownContentPT) {
+	const { isOpen, boxRef } = useNTPulldown()
+
 	return (
-		<button
+		<div
+			ref={boxRef}
 			className={cn(
-				"group flex w-full items-center justify-between bg-transparent px-6 py-[10px]",
-				isOpen && "rounded-t-[14px]",
+				positionVariants({ position }),
+				isOpen ? "max-h-[300px] opacity-100" : "max-h-0 opacity-0",
+				"scrollbar-none overflow-y-scroll transition-all duration-500 ease-in-out",
+				className,
 			)}
-			onClick={() => clickCallback()}
 		>
-			<div className="text-Body01 text-Gray70">{optionArr[0]}</div>
-			<NTArrow
-				isOpen={isOpen}
-				className={cn("", isOpen && "group-hover:text-Gray100")}
-			/>
-		</button>
-	)
-}
-
-function NTPulldownItems({
-	optionArr,
-	clickCallback,
-	isOpen,
-}: NTPulldownItemsPT) {
-	const itemArrExcludeFirst = getItemArrExcludeFirst(optionArr)
-	return (
-		<div className="h-fit w-full">
-			{itemArrExcludeFirst.map((item, idx) => (
-				<div
-					key={idx}
-					className={cn(
-						"group",
-						isLastItem(itemArrExcludeFirst.length, idx) && "rounded-b-[14px]",
-					)}
-				>
-					<hr className="w-full bg-Gray10" />
-					<div
-						className="flex h-fit w-full items-center justify-between px-6 py-[10px] text-Body01 text-Gray70"
-						onMouseDown={() => clickCallback(idx)}
-					>
-						{item}
-						<NTArrow isOpen={isOpen} className="group-hover:text-Gray100" />
-					</div>
-				</div>
-			))}
+			{children}
 		</div>
 	)
 }
 
-const isLastItem = (length: number, idx: number): boolean => {
-	return idx + 1 === length ? true : false
+/**
+ * ------------------------ NTPulldownLabel ------------------------
+ * Pulldown의 제목 또는 레이블을 표시하는 컴포넌트입니다.
+ *
+ * @param children - 레이블로 사용할 내용
+ * @param className - 추가적인 CSS 클래스
+ *
+ */
+type NTPulldownLabelPT = { children: ReactNode; className?: string }
+export function NTPulldownLabel({ children, className }: NTPulldownLabelPT) {
+	return <div className={className}>{children}</div>
 }
-const getItemArrExcludeFirst = (arr: Array<string>) => {
-	return arr.slice(1)
+
+/**
+ * ------------------------ NTPulldownItem ------------------------
+ * Pulldown에서 선택할 항목을 표시하는 컴포넌트입니다.
+ *
+ * @param children - 항목으로 사용할 내용
+ * @param className - 추가적인 CSS 클래스
+ * @param onClick - 항목 클릭 시 호출되는 이벤트 핸들러
+ *
+ */
+type NTPulldownItemPT = {
+	children: ReactNode
+	className?: string
+} & HTMLAttributes<HTMLDivElement>
+export function NTPulldownItem({
+	children,
+	className,
+	onClick,
+	...rest
+}: NTPulldownItemPT) {
+	return (
+		<div
+			className={cn("transition-all duration-500 ease-in-out", className)}
+			{...rest}
+			onMouseDown={onClick}
+		>
+			{children}
+		</div>
+	)
 }

--- a/src/component/custom/manager/base/layout/01/index.tsx
+++ b/src/component/custom/manager/base/layout/01/index.tsx
@@ -1,12 +1,18 @@
 "use client"
 import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
-import { useRef } from "react"
 
 import NTLogo from "@/../public/asset/nt-logo.svg"
+import {
+	NTPulldownContent,
+	NTPulldownItem,
+	NTPulldownLabel,
+	NTPulldownTrigger,
+	useNTPulldown,
+} from "@/component/common/atom/nt-pulldown"
 import NTIcon from "@/component/common/nt-icon"
-import NTSearchfield from "@/component/common/nt-searchfield"
 import NTToolbar from "@/component/common/nt-toolbar"
+import { cn } from "@/config/tailwind"
 import {
 	MANAGER_BASE_MYSHOP_HOME,
 	MANAGER_BASE_SCHEDULE_LIST,
@@ -33,24 +39,61 @@ function ManagerLayoutCatalog() {
 	return (
 		<div className="flex h-[51px] w-full items-center justify-between">
 			<ManagerLayoutPullDown />
-			<ManagerLayoutSearchfield />
+			{/* <ManagerLayoutSearchfield /> */}
 			<ManagerLayoutSubCatalog />
 		</div>
 	)
 }
+
 function ManagerLayoutPullDown() {
+	const { isOpen, clickedIdx, selectIdx } = useNTPulldown()
+	const ShopList = ["모비네일 한남", "다라네일 한남", "마바네일 한남"]
 	return (
-		<div className="h-[45px] w-[134px] bg-Gray10 text-Gray100">pull down</div>
-	)
-}
-function ManagerLayoutSearchfield() {
-	const searchInputRef = useRef<HTMLInputElement>(null)
-	return (
-		<div className="mx-[70px] h-full w-[690px]">
-			<NTSearchfield size="large" ref={searchInputRef} />
+		<div className="relative h-fit w-fit">
+			<NTPulldownTrigger className="flex w-[134px] min-w-[134px] cursor-pointer items-center justify-center gap-x-1 rounded-[6px] border border-transparent bg-Gray10 px-[6px] py-[8px] transition-all duration-500 ease-in-out hover:border-Gray40">
+				<h2 className="truncate text-[16px] font-Medium">
+					{ShopList[clickedIdx]}
+				</h2>
+				<NTIcon
+					icon="expandDownLight"
+					className={cn(
+						"h-6 w-6 text-Gray40 transition-all duration-75",
+						isOpen ? "-rotate-180" : "",
+					)}
+				/>
+			</NTPulldownTrigger>
+			<NTPulldownContent position="left" className="rounded-[14px]">
+				<NTPulldownLabel className="border-b-[1px] border-Gray40 px-2 py-3 text-Body01 font-SemiBold text-Gray80">
+					지점을 선택해주세요
+				</NTPulldownLabel>
+				{ShopList.map((shop, idx) => (
+					<NTPulldownItem
+						className="flex cursor-pointer items-center justify-between px-4 py-2 hover:bg-Gray10"
+						key={idx}
+						onClick={() => selectIdx(idx)}
+					>
+						<p className="truncate text-Body02 text-Gray70">{shop}</p>
+						<NTIcon
+							icon="check"
+							className={cn(
+								"h-6 w-6",
+								clickedIdx === idx ? "opacity-100" : "opacity-0",
+							)}
+						/>
+					</NTPulldownItem>
+				))}
+			</NTPulldownContent>
 		</div>
 	)
 }
+// function ManagerLayoutSearchfield() {
+//    const searchInputRef = useRef<HTMLInputElement>(null)
+//    return (
+//       <div className="mx-[70px] h-full w-[690px]">
+//          <NTSearchfield size="large" ref={searchInputRef} />
+//       </div>
+//    )
+// }
 function ManagerLayoutSubCatalog() {
 	return (
 		<div className="flex w-[236px] items-center justify-end gap-[12px] pr-[21px]">

--- a/src/config/tailwind/global.css
+++ b/src/config/tailwind/global.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 @layer utilities {
+	.scrollbar-none::-webkit-scrollbar {
+		@apply hidden;
+	}
+
 	.scrollbar::-webkit-scrollbar {
 		@apply w-[14px];
 	}

--- a/src/constant/toolbar-list.ts
+++ b/src/constant/toolbar-list.ts
@@ -15,8 +15,8 @@ import {
 export const LABEL_LIST_FOR_MANAGER_BASE_TOOLBAR = [
 	"홈",
 	"일정",
-	"채팅",
-	"내 샵",
+	// "채팅",
+	// "내 샵",
 ] as const
 export const PATH_LIST_FOR_MANAGER_BASE_TOOLBAR = [
 	MANAGER_BASE_HOME,


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->
## [toolbar 경로 주석처리]
- [🔥 사용하지 않는 toolbar경로 주석처리](https://github.com/mobi-projects/nail-case-client/commit/ae0497c88575f7435c12007ec3031a0a11b391b8)

> MVP에 포함안되는 toolbar항목은 주석처리 했습니다.

## [scrollbar-none]
- [🎨 scroll-bar-none class 추가](https://github.com/mobi-projects/nail-case-client/commit/f907563adbf0430760b7fed049e944e7e44c66e1)

> scrollbar-none class추가했습니다.

```tsx
// 사용방법

const ScrollNone =()=> <div className="scrollbar-none">스크롤바 없음</div>
// className에 scrollbar-none 추가하면 스크롤바 없이 스크롤 가능합니다.
```

## [NTPulldown 재설계]
- [⚡️ NTPulldown refactor](https://github.com/mobi-projects/nail-case-client/commit/7df43c1659cc37b6d798823131f44b181018bece)

### [바뀐 설계]
> [shadcn ui](https://ui.shadcn.com/docs/components/dropdown-menu)의 사용법과 동일하게 사용하도록 했습니다.

### [사용 방법]

**1. NTPulldown을 사용하기 위해서 `<NTPulldown Provider>`의 자식으로 포함된 컴포넌트여야 합니다.**
```tsx
<NTPulldownProvider>    ---------------------
  <div className="w-full pb-[42px]">
        <ManagerBaseHeader />          ---------------> Manager 에서 사용하도록 provider 적용
             <NTToast />
  
    {children}
 </div>
</NTPulldownProvider>  ----------------------
```

**2. provider아래에서 trigger, content , label, item 컴포넌트를 사용해서 pulldown을 만들 수 있습니다.**
- 각 컴포넌트의 역할, 사용방법에 대해서는 주석 작성했습니다.
- pulldown의 구성 컴포넌트 들은 provider의 하위에 있기때문에 useNTPulldown의 return값들을 사용 할 수 있습니다.
```tsx
const { isOpen, clickedIdx, selectIdx, boxRef, toggleOpen, triggerRef } = useNTPulldown()
// provider 하위의 컴포넌트가 모두 공유해서 사용할 수 있는 context
```

**3. NTPulldown컴포넌트는 기본적인 css만 적용해둔 상태입니다.**
- 컴포넌트의 디자인에 맞게 사용할때 className을 추가해서 디자인하면 됩니다.


## [판매자 header에 NTPulldown 적용]
- [🎨 판매자 header에 NTPulldown 적용](https://github.com/mobi-projects/nail-case-client/commit/3b822e690c6f3adbc6a5a3e9ae4f719f7354d433)

<div align="center">

![bandicam-2024-07-22-16-02-12-163](https://github.com/user-attachments/assets/47c8cb33-8fb4-4023-81ef-a5b6d01c2dea)

</div>

### [pulldown의 항목중 text가 7자가 넘어가면 어떻게 처리하면 좋을까요..?]
<div align="center">

#### 띄어쓰기 포함 7자가 넘어갈때

![bandicam-2024-07-22-15-58-37-574](https://github.com/user-attachments/assets/47702938-d104-471a-8b10-f769176b650f)

> 우선은 truncate를 적용해서 ... 으로 처리했는데 의견좀 부탁드립니다.

</div>

<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
