### PR TITLE
fix : logout 에러 수정

### DIFF
--- a/src/component/custom/customer/home/00/index.tsx
+++ b/src/component/custom/customer/home/00/index.tsx
@@ -3,17 +3,16 @@ import { getCookie } from "cookies-next"
 import Image from "next/image"
 import { useRouter } from "next/navigation"
 import * as React from "react"
-import { Toaster, toast } from "sonner"
+import { Toaster } from "sonner"
 
 import NTLogo from "@/../public/asset/nt-logo.svg"
 import { NTButton } from "@/component/common/atom/nt-button"
 import NTIcon from "@/component/common/nt-icon"
 import NTToolbar from "@/component/common/nt-toolbar"
 import { useAuth } from "@/config/auth-provider"
-import { COMMON_HOME, COMMON_SIGN } from "@/constant/routing-path"
+import { COMMON_SIGN } from "@/constant/routing-path"
 import { LABEL_LIST_FOR_CUSTOMER_BASE_TOOLBAR } from "@/constant/toolbar-list"
-import { postLogout } from "@/util/api/auth-controller"
-import { deleteAllCookies } from "@/util/common/auth"
+import { handleLogout } from "@/util/common/auth"
 
 export default function CustomerHeader() {
 	const { isAuthenticated } = useAuth()
@@ -35,19 +34,6 @@ export default function CustomerHeader() {
 }
 
 function CustomerLayoutSubCatalog() {
-	const handleLogout = async () => {
-		const response = await postLogout()
-		if (response?.status === 200) {
-			deleteAllCookies()
-			toast.success("안녕히 가세요")
-			setTimeout(() => {
-				window.location.href = COMMON_HOME
-			}, 1000)
-		} else {
-			toast.warning("로그아웃에 실패했습니다.")
-		}
-	}
-
 	const profileUrl = getCookie("profile-image") || ""
 
 	return (

--- a/src/util/api/auth-controller.ts
+++ b/src/util/api/auth-controller.ts
@@ -1,8 +1,8 @@
 import axios from "axios"
-import { getCookie } from "cookies-next"
+import { getCookie, hasCookie } from "cookies-next"
 
 import { axiosInstance } from "@/config/axios"
-import { REFRESH_TOKEN } from "@/constant/auth-key"
+import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constant/auth-key"
 import type { TSignType } from "@/type/union-option/sign-type"
 
 /** [GET] 로그인 요청 api 호출 */
@@ -38,13 +38,18 @@ export const postResquestNewToken = async () => {
 
 /** [POST] 로그아웃 요청 api 호출 */
 export const postLogout = async () => {
+	const accessToken = hasCookie(ACCESS_TOKEN)
+		? getCookie(ACCESS_TOKEN)
+		: "no accessToken"
+
 	const refreshToken = getCookie(REFRESH_TOKEN)
 
-	const response = await axiosInstance().post(
-		`/auth/logout`,
+	const response = await axios.post(
+		`${process.env.NEXT_PUBLIC_BACKEND_APP}/auth/logout`,
 		{},
 		{
 			headers: {
+				Authorization: `Bearer ${accessToken}`,
 				"Refresh-Token": `Bearer ${refreshToken}`, // Refresh Token (Header로 보내야 함)
 			},
 		},

--- a/src/util/common/auth.ts
+++ b/src/util/common/auth.ts
@@ -1,7 +1,12 @@
+import { isAxiosError } from "axios"
 import { deleteCookie, setCookie } from "cookies-next"
+import { toast } from "sonner"
 
 import { ACCESS_TOKEN, IS_MANAGER, REFRESH_TOKEN } from "@/constant/auth-key"
+import { COMMON_HOME } from "@/constant/routing-path"
 import type { TSignDataResponse, TRefreshDataResponse } from "@/type"
+
+import { postLogout } from "../api/auth-controller"
 
 export const initAuthTokens = ({
 	accessToken,
@@ -28,4 +33,22 @@ export const deleteAllCookies = () => {
 	deleteCookie(IS_MANAGER)
 	deleteCookie(REFRESH_TOKEN)
 	deleteCookie("profile-image")
+}
+
+export const handleLogout = async () => {
+	try {
+		await postLogout()
+		toast.success("안녕히 가세요")
+	} catch (error) {
+		if (isAxiosError(error) && error.response?.status === 500) {
+			toast.warning("네트워크 문제가 발생했습니다. 다시 로그인 해주세요")
+		} else {
+			toast.error("로그아웃 중 오류가 발생했습니다.")
+		}
+	} finally {
+		deleteAllCookies()
+		setTimeout(() => {
+			window.location.href = COMMON_HOME
+		}, 1000)
+	}
 }


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-360](https://nailcase.atlassian.net/browse/NAILCASE-360)
<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## [로그아웃 로직 수정!]
- [🐛 로그아웃 api로직 수정](https://github.com/mobi-projects/nail-case-client/commit/dce2470858210c877c2d0bec156c1b96dd296314)

## [기존 error case]

클라이언트 측에서 각 토큰의 만료시간은 다음과 같이 설정해두었습니다.
> refreshToken : 백엔드 서버와 동일하게 24시간 (1일)
> accessToken : 클라이언트의 session 유지시간
> - instacse를 사용하기 때문에 만일 백엔드 측에서 만료된 accessToken을 받는다면 401에러를 반환하고 istancse에 의해 토큰 refresh후 새로운 토큰으로 기존 api요청을 보내기때문

여기서 error case가 발생했는데요..
> 사용자가 session종료후 사이트에 접속한다면? => refreshToken은 유지, accessToken은 없는상태
> 로그아웃 api 호출 => 응답으로 500번 에러를 반환 받습니다.
> - instacse에는 401, 즉 만료된 토큰 요청에 한해서 재요청을 보내도록 동작하기 때문에 원치않는 동작을 수행했습니다.

## [해결 방법]

이에 대해 백엔드와 상의해본 결과입니다. _(성공 case는 잘동작하니 설명에서 제외합니다.)_

-> 백엔드 측에서 로그아웃 요청을 받았을 경우
> case : accessToken에 undefined가 아닌 임의의 string이 올경우
> - 백엔드 측에서는 해당 사용자의 refreshToken은 만료, accessToken은 유지가 됩니다. (1시간동안)
> - 백엔드 측에서 accessToken삭제가 불가능 하다고합니다. 따라서 블랙리스트에 올려두고 해당 토큰으로 만약 요청이 올 경우 요청은 거절된다고 하네요.
> - 응답으로는 성공 응답이 옵니다.

> case : refreshToken에 undefined가 아닌 임의의 string이 올경우
> - 백엔드 측에서는 해당 사용자의 refreshToken은 유효합니다.
> - 응답으로는 성공 응답이 옵니다.

> case : undefined인 accessToken이 전달될 경우 
> - 응답으로 500번 에러를 반환합니다.

> case : undefined인 refreshToken이 전달될 경우
> - 해당 case는 존재할 수 없습니다. (refreshToken이 없다면 로그아웃 버튼이 존재할 수 가 없습니다.)

여기서 error case에 대해 다루는 방법에 대해 고민해봤는데요.. 만약 에러가 발생했을 경우 사용자는 다른 액션을 취할 방법이 없다고 판단이 됩니다.  네트워크오류가 아닌 이상 사용자는 서버로 토큰값을 변경해서 보낼 방법이 없습니다.

따라서 모든 case에 cookie를 삭제시키고 홈으로이동 시키는 동작을 하도록 했습니다.

**단..!** 에러 케이스가 발생한다면 toast메세지만 다르게 보여주는 형식으로 코드를 수정했습니다.

- [🚚 handleLogout 로직수정 & 관리위치 변경](https://github.com/mobi-projects/nail-case-client/commit/8d753595e415425379719ecea27366dd149fdf68)

## [결과물]

<div align="center">


https://github.com/user-attachments/assets/b3184659-3a9f-4883-80c6-06f1ce6ba92e



> case :  session종료, 즉 accessToken 없이 로그아웃 요청을 보낼때


https://github.com/user-attachments/assets/e98a3592-5f99-449d-9fd7-46b2122e4b5e

> case : 잘못된 refreshToken으로 로그아웃 요청을 보낼때


https://github.com/user-attachments/assets/a88d1778-500b-4b69-816b-6172d5291bae

> case : 서버에러 (네트워크에러 500번) 이 발생했을 경우

</div>


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-360]: https://nailcase.atlassian.net/browse/NAILCASE-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ