### PR TITLE
feat : 서버패칭시 사용할 axiosInstanceServer 설정 추가

### DIFF
--- a/src/config/axios/instance-server.ts
+++ b/src/config/axios/instance-server.ts
@@ -1,0 +1,41 @@
+import type { AxiosInstance, AxiosRequestConfig } from "axios"
+import axios from "axios"
+import { getCookie } from "cookies-next"
+import { cookies } from "next/headers"
+
+import { ACCESS_TOKEN } from "@/constant/auth-key"
+
+const instanceConfig: AxiosRequestConfig = {
+	baseURL: process.env.NEXT_PUBLIC_BACKEND_APP,
+	headers: {
+		"Content-Type": "application/json",
+	},
+	withCredentials: true,
+}
+
+export const axiosInstanceServer = () => {
+	let instance = axios.create(instanceConfig)
+	instance = setRequestInterceptor(instance)
+
+	return instance
+}
+
+/** "요청" 인터셉터 설정 */
+const setRequestInterceptor = (instance: AxiosInstance) => {
+	instance.interceptors.request.use(
+		(config) => {
+			const accessToken = getCookie(ACCESS_TOKEN, { cookies })
+			if (accessToken && config.headers) {
+				config.headers.Authorization = `Bearer ${accessToken}`
+			}
+			return config
+		},
+		(error) => Promise.reject(error),
+	)
+	instance.defaults.paramsSerializer = function (paramObj) {
+		const params = new URLSearchParams()
+		for (const key in paramObj) params.append(key, paramObj[key])
+		return params.toString()
+	}
+	return instance
+}

--- a/src/config/tanstack-query/tanstack-query-provider.tsx
+++ b/src/config/tanstack-query/tanstack-query-provider.tsx
@@ -1,33 +1,25 @@
 "use client"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
-import type { PropsWithChildren } from "react"
+import { useState, type PropsWithChildren } from "react"
 
 export default function TanstackQueryProvider({ children }: PropsWithChildren) {
-	const queryClient = getQueryClient()
+	const [queryClient] = useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						refetchOnWindowFocus: true,
+						refetchOnMount: true,
+						staleTime: 60 * 1000,
+					},
+				},
+			}),
+	)
 	return (
 		<QueryClientProvider client={queryClient}>
 			{children}
 			<ReactQueryDevtools initialIsOpen={false} />
 		</QueryClientProvider>
 	)
-}
-let browserQueryClient: QueryClient | undefined = undefined
-const createNewQueryClient = () => {
-	return new QueryClient({
-		defaultOptions: {
-			queries: {
-				refetchOnWindowFocus: true,
-				refetchOnMount: true,
-				staleTime: 60 * 1000,
-			},
-		},
-	})
-}
-const getQueryClient = () => {
-	if (typeof window === "undefined") return createNewQueryClient()
-	else {
-		if (!browserQueryClient) browserQueryClient = createNewQueryClient()
-		return browserQueryClient
-	}
 }


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-370](https://nailcase.atlassian.net/browse/NAILCASE-370)

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## [리뷰하기 전에..!]

prefetchQuery 와 HydrationBoundary에대해 궁굼증이 있을것 같아서 codeSandBox에 주석과, 예시코드를 작성해봤습니다.
- [여기](https://codesandbox.io/p/devbox/hydration-test-s7flst?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clz2e3aay0006356kuwz1oy3d%2522%252C%2522sizes%2522%253A%255B79.0170481869426%252C20.982951813057397%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clz2e3aay0002356krolq7c6m%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clz2e3aay0004356kzg75iv5h%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clz2e3aay0005356kgy9i7n4m%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clz2e3aay0002356krolq7c6m%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clz2e3aax0001356kiuk3ddd3%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clz2e3aay0002356krolq7c6m%2522%252C%2522activeTabId%2522%253A%2522clz2e3aax0001356kiuk3ddd3%2522%257D%252C%2522clz2e3aay0005356kgy9i7n4m%2522%253A%257B%2522id%2522%253A%2522clz2e3aay0005356kgy9i7n4m%2522%252C%2522activeTabId%2522%253A%2522clz2e647a0086356knfg9mclv%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TESTS%2522%252C%2522id%2522%253A%2522clz2e647a0086356knfg9mclv%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%252C%2522clz2e3aay0004356kzg75iv5h%2522%253A%257B%2522id%2522%253A%2522clz2e3aay0004356kzg75iv5h%2522%252C%2522activeTabId%2522%253A%2522clz2mhe4b00ee356kbpehm9kr%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clz2gwqlg0020dci55z9d67ko%2522%252C%2522id%2522%253A%2522clz2mhe4b00ee356kbpehm9kr%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)서 예시코드를 확인해주세요!

_처음 적용해보는 내용이라 설명할것이 많아서 pr이조금 길어지네요. 죄성합니다._


## [axiosInstanceServer]
- [🔧 axios instance server 추가](https://github.com/mobi-projects/nail-case-client/commit/d05916e0943f70d464df9ab1cfdf33f6d996a8ca)

### axiosInstanceServer가 있어야하는 이유

> 기존instance에서 props를 이용해서 분기처리후 사용하면 되는거아니야? 라는 생각을 할 수 있는데요 ... 저도 시도해봤습니다.

> 우선 저희가 사용하는 [cookies-next라이브러리](https://github.com/andreizanik/cookies-next)에 대해 알아야 하는데요 
> 공식문서에서 확인해보면 쿠키를 가져오는 방법이 server환경과 client환경에서 다릅니다.

> client일 경우 getCookie(key) // key값만 입력하면 key에맞는 쿠키를 가져옵니다.
> server일 경우 getCookies(key, { cookies }) // cookies라는 것을 같이 전달해야합니다.
> - cookies는 next/header에서 import해서 사용하는데요. cookies는 server에서만 동작합니다.
> - import {cookies} from "next/headers" 라는 import문이 "use server"키워드 없는 환경에서 실행된다면 다음과 같은 에러가 발생합니다.

<div align="centner">
<img width="880" alt="image" src="https://github.com/user-attachments/assets/50e8686a-7ca8-47f0-b448-21d86fd75435">

</div>

이러한 이유로 axiosInstanceServer를 추가하게 되었습니다.


### 왜 삭제했나요?

**새로 추가된 axiosInstanceServer에는 실패시 재요청하는 inteceptor response가 없는데요.. 에러사항이 있어서 삭제를 했습니다.**

> 현재 서버패칭 과정에서 가장문제가 되는 것은 서버환경에서 setCookies가 불가능 하다는 점입니다.

> 여기서 궁굼증이 생길 수 있는데요. 백엔드에서 설정한 token의 만료시간은 1시간인데 
> 그렇다면 1시간후에는 요청이 무조건 실패할태니 사용자는 화면을 못보는거아니야? 라는 의문이 생길것 같습니다.

**이에대한 제 해결책은 이렇습니다.**

```tsx
// 서버컴포넌트에서 서버패칭을 실행할때 
const  ServerComp =async () => {
   prefetchQuery를 통해 미리 서버패칭
}

// 클라이언트 컴포넌트에서 패칭을 실행할 때
const ClientComp =  ()=>{
  useQuery를 사용해서 api를 호출 합니다.
 }

``` 

> fetching과정을 간단히 살펴보면 위와같은 과정을 따르는데요 
>  제가 실행해본 결과 만약 서버패칭이 실패한다면 오류를 발생시키지 않습니다.

> 서버패칭실패시 => 클라이언트에서 useQuery를 실행하면 클라이언트측 api호출이 일어나서 패칭을 진행합니다.

> 위와같은 문제가일어날 상황은 1시간후 토큰만료상황인데요..
> 그렇다면 1시간에 한번 서버패칭이 실패할태고 클라이언트 호출로 바뀌게 됩니다.
> 이때 클라이언트 instance에 의해 토큰 재발급 요청이 일어나서 토큰을 갱신합니다.
> 그 후 실행되는 서버요청들은 모두 새로운 토큰으로 실행되니 1시간에 1번 클라이언트 호출이 일어나는것이 조금 흠이긴 한데... 가장 문제가되는 상황은 당장 해결이되긴합니다..

### 적용하는 방법

**1. server action함수 정의**

>조금 번거로울 수 도있는데 server fetching에 사용할 serverInstance를 가진 axios를 사용해서 api를 호출 해야합니다.
> **또한 가장 중요한 점은 위에서 언급한 cookies때문에 api호출 파일 최상단에 "use server" keyword를 사용해야합니다.**

**2. server action함수를 사용해서 서버컴포넌트에서 data prefetch**

**3. 클라이언트 컴포넌트에서 동작**
> 클라이언트 컴포넌트 측에서는 useQuery를 사용해서 데이터를 받아옵니다. 
> 이 때 ..! prefetch에 사용한 queryKey와 꼭 동일한 key로 호출해야합니다.
> 이때 사용하는 함수는 기존에 axiosInstace를 사용했던 api함수를 그대로 사용해도 상관없습니다.



## [QueryClientProvider 설정 변경 ]
- [⚡️ 전역 QueryClientProvider 설정 변경](https://github.com/mobi-projects/nail-case-client/commit/b8a063ab2b3c59713c5dc40f793780980cac0e5e)

> 기존 프로바이더는 if문을 통해 window의 상태로 클라이언트 요청 or 서버요청을 판별하도록 되어있엇습니다.
> 새로운 provider는 state에 queryClient를 적용했습니다.
> - state를 사용한 이유는 리랜더가 일어나도 기존 queryClient의 설정이 유지되도록 하기 위함이라고 하네요..


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-370]: https://nailcase.atlassian.net/browse/NAILCASE-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ