### PR TITLE
refactor : 서버환경, 클라이언트환경 둘다 적용가능한 axios-instance 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"cookies-next": "^4.2.1",
 				"dayjs": "^1.11.11",
 				"embla-carousel-react": "^8.1.6",
+				"jwt-decode": "^4.0.0",
 				"lucide-react": "^0.390.0",
 				"next": "14.2.3",
 				"prettier": "^3.2.5",
@@ -12446,6 +12447,14 @@
 			},
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"cookies-next": "^4.2.1",
 		"dayjs": "^1.11.11",
 		"embla-carousel-react": "^8.1.6",
+		"jwt-decode": "^4.0.0",
 		"lucide-react": "^0.390.0",
 		"next": "14.2.3",
 		"prettier": "^3.2.5",

--- a/src/config/axios/get-client-cookie.ts
+++ b/src/config/axios/get-client-cookie.ts
@@ -1,0 +1,7 @@
+import { getCookie } from "cookies-next"
+
+import { ACCESS_TOKEN } from "@/constant/auth-key"
+
+export const getClientCookie = () => {
+	return getCookie(ACCESS_TOKEN)
+}

--- a/src/config/axios/get-server-cookie.ts
+++ b/src/config/axios/get-server-cookie.ts
@@ -1,0 +1,9 @@
+"use server"
+import { getCookie } from "cookies-next"
+import { cookies } from "next/headers"
+
+import { ACCESS_TOKEN } from "@/constant/auth-key"
+
+export const getServerCookie = () => {
+	return getCookie(ACCESS_TOKEN, { cookies })
+}

--- a/src/config/axios/instance.utll.ts
+++ b/src/config/axios/instance.utll.ts
@@ -1,27 +1,60 @@
-import type { InternalAxiosRequestConfig } from "axios"
-import axios from "axios"
+import type { AxiosResponse } from "axios"
+import { type CookieValueTypes } from "cookies-next"
+import { jwtDecode } from "jwt-decode"
 
+import type { TRefreshDataResponse } from "@/type"
 import { postResquestNewToken } from "@/util/api/auth-controller"
+import { getNowStamp } from "@/util/common"
 import { setAuthTokens } from "@/util/common/auth"
-import { isUndefined } from "@/util/common/type-guard"
+import { isNull, isUndefined } from "@/util/common/type-guard"
 
-// import { setTokens } from "./instance"
+import { getClientCookie } from "./get-client-cookie"
+import { getServerCookie } from "./get-server-cookie"
 
-//**********  401 에러 발생 시 실행 *************//
-export const handleUnauthorized401 = async (
-	config: InternalAxiosRequestConfig | undefined,
-) => {
-	const originalRequest = config
-	if (isUndefined(originalRequest)) return
-	try {
-		// 토큰 refresh요청
-		const response = await postResquestNewToken()
-		// cookie 재설정
-		setAuthTokens(response.data)
-		// 기존 api요청 header에 재발급 받은 accessToken을 담아서 재요청
-		originalRequest.headers.Authorization = `Bearer ${response.data.accessToken}`
-		return axios(originalRequest)
-	} catch (error) {
-		throw error
+let refreshTokenPromise: Promise<AxiosResponse<TRefreshDataResponse>> | null =
+	null
+
+/** 토큰의 만료 여부에 따라서 만료가 안 됐다면 기존 토큰 사용, 만료된 토큰이라면 토큰 갱신 후 갱신된 accessToken 반환 */
+export const getValidAccessToken = async (
+	token: CookieValueTypes,
+): Promise<string> => {
+	if (isExpired(token) && typeof window !== "undefined") {
+		if (isNull(refreshTokenPromise)) {
+			try {
+				refreshTokenPromise = postResquestNewToken()
+				const response = await refreshTokenPromise
+				setAuthTokens(response.data) // 새로운 토큰 설정
+				return response.data.accessToken // 갱신된 액세스 토큰 반환
+			} catch (error) {
+				return Promise.reject(error)
+			} finally {
+				refreshTokenPromise = null
+			}
+		}
+		const response = await refreshTokenPromise
+		return response.data.accessToken // 갱신된 accessToken정보 반환
 	}
+
+	return token as string // 기존 accessToken정보 반환
+}
+/** 전달받은 accessToken을 현재 timeStamp와 비교해서 만료된 토큰 여부 판단 */
+export const isExpired = (token: CookieValueTypes): boolean => {
+	const expTime = getTokenExpireTime(token)
+	const now = getNowStamp()
+	return expTime <= now
+}
+
+/** 전달받은 accessToken을 decode해서 만료시간 반환 */
+const getTokenExpireTime = (token: CookieValueTypes): number => {
+	if (isUndefined(token)) return 0
+	const expireTime = jwtDecode(token).exp
+	if (isUndefined(expireTime)) return 0
+	return expireTime
+}
+
+/** 실행 환경 (server or client) 인지 판별해서 환경에 맞는 accessToken 반환 */
+export const getAccessToken = async (): Promise<string | undefined> => {
+	const token =
+		typeof window === "undefined" ? getServerCookie() : getClientCookie()
+	return Promise.resolve(token)
 }

--- a/src/config/axios/instance.utll.ts
+++ b/src/config/axios/instance.utll.ts
@@ -16,6 +16,7 @@ let refreshPromise: Promise<AxiosResponse<TRefreshDataResponse>> | null = null
 
 /** 토큰의 만료 여부에 따라서 만료가 안 됐다면 기존 토큰 사용, 만료된 토큰이라면 토큰 갱신 후 갱신된 accessToken 반환 */
 export const getValidAccessToken = async (token: CookieValueTypes) => {
+	if (isServer()) return token as string
 	if (!isExpired(token)) return token as string // 유효한 토큰이라면 그대로 반환
 
 	if (isNull(refreshPromise)) {

--- a/src/config/axios/instance.utll.ts
+++ b/src/config/axios/instance.utll.ts
@@ -2,46 +2,60 @@ import type { AxiosResponse } from "axios"
 import { type CookieValueTypes } from "cookies-next"
 import { jwtDecode } from "jwt-decode"
 
+import { COMMON_HOME } from "@/constant/routing-path"
 import type { TRefreshDataResponse } from "@/type"
 import { postResquestNewToken } from "@/util/api/auth-controller"
 import { getNowStamp } from "@/util/common"
-import { setAuthTokens } from "@/util/common/auth"
+import { deleteAllCookies, setAuthTokens } from "@/util/common/auth"
 import { isNull, isUndefined } from "@/util/common/type-guard"
 
 import { getClientCookie } from "./get-client-cookie"
 import { getServerCookie } from "./get-server-cookie"
 
-let refreshTokenPromise: Promise<AxiosResponse<TRefreshDataResponse>> | null =
-	null
+let refreshPromise: Promise<AxiosResponse<TRefreshDataResponse>> | null = null
 
 /** 토큰의 만료 여부에 따라서 만료가 안 됐다면 기존 토큰 사용, 만료된 토큰이라면 토큰 갱신 후 갱신된 accessToken 반환 */
 export const getValidAccessToken = async (
 	token: CookieValueTypes,
 ): Promise<string> => {
-	if (isExpired(token) && typeof window !== "undefined") {
-		if (isNull(refreshTokenPromise)) {
+	if (isExpired(token) && !isServer()) {
+		if (isNull(refreshPromise)) {
 			try {
-				refreshTokenPromise = postResquestNewToken()
-				const response = await refreshTokenPromise
-				setAuthTokens(response.data) // 새로운 토큰 설정
-				return response.data.accessToken // 갱신된 액세스 토큰 반환
+				refreshPromise = postResquestNewToken()
+				const { data: newTokens } = await refreshPromise
+				setAuthTokens(newTokens) // 새로운 토큰 설정
+				return newTokens.accessToken // 갱신된 액세스 토큰 반환
 			} catch (error) {
+				handleRefreshingError()
 				return Promise.reject(error)
 			} finally {
-				refreshTokenPromise = null
+				refreshPromise = null
 			}
+		} else {
+			const { data: newTokens } = await refreshPromise
+			return newTokens.accessToken // 기존 요청중인 토큰 갱신을 기다린후 새로발급된 accessToken을 반환
 		}
-		const response = await refreshTokenPromise
-		return response.data.accessToken // 갱신된 accessToken정보 반환
 	}
 
 	return token as string // 기존 accessToken정보 반환
 }
+
+/** 에러 발생시 세션만료 & 사용자 홈으로 redirect */
+const handleRefreshingError = () => {
+	deleteAllCookies()
+	window.location.href = COMMON_HOME
+}
+
 /** 전달받은 accessToken을 현재 timeStamp와 비교해서 만료된 토큰 여부 판단 */
 export const isExpired = (token: CookieValueTypes): boolean => {
 	const expTime = getTokenExpireTime(token)
 	const now = getNowStamp()
 	return expTime <= now
+}
+
+/** server or client 어떤환경에서 실행하는지 반환 */
+export const isServer = (): boolean => {
+	return typeof window === "undefined"
 }
 
 /** 전달받은 accessToken을 decode해서 만료시간 반환 */
@@ -54,7 +68,6 @@ const getTokenExpireTime = (token: CookieValueTypes): number => {
 
 /** 실행 환경 (server or client) 인지 판별해서 환경에 맞는 accessToken 반환 */
 export const getAccessToken = async (): Promise<string | undefined> => {
-	const token =
-		typeof window === "undefined" ? getServerCookie() : getClientCookie()
+	const token = isServer() ? getServerCookie() : getClientCookie()
 	return Promise.resolve(token)
 }

--- a/src/util/api/auth-controller.ts
+++ b/src/util/api/auth-controller.ts
@@ -1,9 +1,10 @@
+import type { AxiosResponse } from "axios"
 import axios from "axios"
 import { getCookie, hasCookie } from "cookies-next"
 
 import { axiosInstance } from "@/config/axios"
 import { ACCESS_TOKEN, REFRESH_TOKEN } from "@/constant/auth-key"
-import type { TUserInfo } from "@/type"
+import type { TRefreshDataResponse, TUserInfo } from "@/type"
 import type { TResponseData } from "@/type/response"
 import type { TSignType } from "@/type/union-option/sign-type"
 
@@ -23,7 +24,9 @@ export const getLogin = async (code: string, loginType: TSignType) => {
 }
 
 /** [POST] 리프레쉬 토큰 api 호출 */
-export const postResquestNewToken = async () => {
+export const postResquestNewToken = async (): Promise<
+	AxiosResponse<TRefreshDataResponse>
+> => {
 	const refreshToken = getCookie(REFRESH_TOKEN)
 
 	const response = await axios.post(
@@ -35,6 +38,7 @@ export const postResquestNewToken = async () => {
 			},
 		},
 	)
+
 	return response
 }
 


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-370](https://nailcase.atlassian.net/browse/NAILCASE-370)

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## [jwt decode]
- [➕ jwt-decode 의존성 추가](https://github.com/mobi-projects/nail-case-client/commit/0b641f12e72b906bd65b7c1293ed90799674ef2f)

> jwt-decode 라이브러리를 설치했습니다.
> accessToken 에서 만료시간 정보를 추출하는 용도로 사용합니다.

## [환경상태에 따라 cookie접근 함수 정의]

- [✨ 환경상태에 따른 accessToken반환 함수 정의](https://github.com/mobi-projects/nail-case-client/commit/2f118c4779648259df3bc696105fc117150505ab)

> 이전에 말씀드린것 처럼 `cookies-next` 의 getCookie를 하기위해서는 서버 , 클라이언트 동작방식이 다릅니다.

```tsx
// 클라이언트 일때
const accessToken = getCookie(키)

// 서버일때
const accessToken = getCookie(키,{cookies}) 
```
- cookies는 next/headers에서 import해서 사용해야하는데 cookies는 서버환경에서만 동작하기 때문에  별도의 파일로 분리했습니다.
## [refresh api요청 반환타입 수정]
- [⚡ 리프레쉬 요청 return type 명시](https://github.com/mobi-projects/nail-case-client/commit/b7d545f0594f1bc5c4dac6d8c6bf7d8a73146f34)

> 기존에 반환타입을 정의안했는데 반환타입 설정해줬습니다.

## [axios-instance refactor]

- [⚡ axios instance refactor](https://github.com/mobi-projects/nail-case-client/commit/5f2a901beff4d3670a94294f90018b4219471bbb)

> 지난 회의때 얘기했던 수정방향
> - instance를 사용할때마다 client인지 server인지 props로 전달받도록 수정하자..! 라고했었습니다.
> - api폴더 또한 새로 만들고, 함수도 다시작성하자..! 라고 정리했엇는데요.

> 실제 refactor된 내용
> - instance를 사용할때마다 props를 작성하는 것이 너무 불편한것 같아서 props사용 안하도록 만들었습니다.
> - instance가 동작할때마다 `typeof window` 를 사용해서 서버인지, 클라이언트인지 check해서 동작하도록 만들었습니다.
> - 결론 : 기존api그대로사용, instance를 사용할 때도 그냥 기존방식과 동일하게 사용.

> api 병렬 요청에 관하여.
> - jwt-decode를 활용해서 요청전에 유효한 토큰인지 검사를 진행하도록 코드가 수정되었는데요
> - 만약 유효하지 않다면 refresh요청후 갱신한 토큰으로 요청이 진행하도록 수정되었습니다.
> - 이때,,! 한가지 문제되는점이 api 병렬 요청의 경우 refresh 요청또한 동시에 실행되는데요 이러면 오류를 발생시킵니다.
> - 따라서..! ==> refresh요청이 실행중이라면 그 후의 요청은 refresh요청을 대기하도록 코드를 설정했습니다.

## [결론]
refactor된 instance를 사용할때 아무것도 신경안써도 됩니다. 기존과 똑같은 방식으로 코드를 작성해도 문제없습니다.
또한 앞으로 api요청을 병렬로 보내도 문제없습니다..!


https://github.com/user-attachments/assets/17ea0f6f-f070-40a3-85c3-1db9e4bd9cc2

> 만료 or refreshToken만 존재할때 api병렬 요청시 token갱신과정


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-370]: https://nailcase.atlassian.net/browse/NAILCASE-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ