### PR TITLE
design : 판매자 홈에서 보여질 이달의 아트 디자인 & 등록여부에 따른 ui분기처리

### DIFF
--- a/src/component/common/nt-icon/index.tsx
+++ b/src/component/common/nt-icon/index.tsx
@@ -66,4 +66,5 @@ export const ICON_DATA = {
 	arrowUp: "uit:arrow-up-right",
 	back: "lets-icons:arrow-left-light",
 	share: "ep:share",
+	camera: "ion:camera-outline",
 } as const

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-list.util.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-list.util.ts
@@ -1,0 +1,16 @@
+export const isOverFiveImages = (
+	imageArr: Array<{
+		imageUrl: string
+		imageId: number
+	}>,
+) => {
+	return imageArr.length > 5
+}
+
+export const isFocusedIdxOverFive = (focusedIdx: number) => {
+	return focusedIdx > 4
+}
+
+export const getSlideCss = (focusedIdx: number) => {
+	return isFocusedIdxOverFive(focusedIdx) ? `-translate-x-[36rem]` : ""
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-single/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-single/index.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image"
+import type { Dispatch, SetStateAction } from "react"
+
+import { cn } from "@/config/tailwind"
+
+type AOMInageBoxPT = {
+	imageUrl: string
+	isFocused: boolean
+	setFocusedIdx: Dispatch<SetStateAction<number>>
+	idx: number
+}
+
+export default function AOMImageSingle({
+	imageUrl,
+	isFocused,
+	setFocusedIdx,
+	idx,
+}: AOMInageBoxPT) {
+	return (
+		<div
+			className="relative h-24 w-24 min-w-24 cursor-pointer rounded-[26px] bg-White shadow-customGray80 transition-all"
+			onClick={() => setFocusedIdx(() => idx)}
+		>
+			<Image
+				alt="이달의 아트"
+				src={imageUrl}
+				fill
+				sizes="30vw"
+				priority
+				className={cn(
+					"rounded-md border-2",
+					isFocused ? "border-PB50" : "border-transparent",
+				)}
+			/>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/index.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import type { Dispatch, SetStateAction } from "react"
+
+import NTIcon from "@/component/common/nt-icon"
+import { cn } from "@/config/tailwind"
+
+import {
+	getSlideCss,
+	isFocusedIdxOverFive,
+	isOverFiveImages,
+} from "./aom-image-list.util"
+import AOMImageSingle from "./aom-image-single"
+
+type AOMImageSectionPT = {
+	aomInfoArr: Array<{
+		imageUrl: string
+		imageId: number
+	}>
+	focusedIdx: number
+	setFocusedIdx: Dispatch<SetStateAction<number>>
+}
+
+export default function AOMImageList({
+	aomInfoArr,
+	focusedIdx,
+	setFocusedIdx,
+}: AOMImageSectionPT) {
+	const slideCss = getSlideCss(focusedIdx)
+
+	const handleNextIcon = () => {
+		if (isOverFiveImages(aomInfoArr) && !isFocusedIdxOverFive(focusedIdx))
+			setFocusedIdx(5)
+	}
+	const handlePrevIcon = () => {
+		if (isOverFiveImages(aomInfoArr) && isFocusedIdxOverFive(focusedIdx))
+			setFocusedIdx(4)
+	}
+
+	return (
+		<div className="flex h-full items-center gap-x-8">
+			<NTIcon
+				icon="expandLeft"
+				className={cn(
+					"h-6 w-6 text-Gray50 transition-all hover:text-Gray80",
+					isOverFiveImages(aomInfoArr) && isFocusedIdxOverFive(focusedIdx)
+						? "cursor-pointer opacity-100"
+						: "cursor-default opacity-0",
+				)}
+				onClick={handlePrevIcon}
+			/>
+			<div
+				className={cn(
+					"relative flex h-full w-[36rem] transform items-center gap-x-5 overflow-x-hidden transition-transform duration-300",
+				)}
+			>
+				<div
+					className={cn(
+						"absolute top-1/2 flex w-full -translate-y-1/2 transform items-center gap-x-5 transition-transform duration-1000",
+						slideCss,
+					)}
+				>
+					{aomInfoArr.map((info, idx) => (
+						<AOMImageSingle
+							imageUrl={info.imageUrl}
+							key={info.imageId}
+							isFocused={focusedIdx === idx}
+							idx={idx}
+							setFocusedIdx={setFocusedIdx}
+						/>
+					))}
+				</div>
+			</div>
+			<NTIcon
+				icon="expandRight"
+				className={cn(
+					"h-6 w-6 cursor-pointer text-Gray50 transition-all hover:text-Gray80",
+					isOverFiveImages(aomInfoArr) && !isFocusedIdxOverFive(focusedIdx)
+						? "cursor-pointer opacity-100"
+						: "cursor-default opacity-0",
+				)}
+				onClick={handleNextIcon}
+			/>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/index.tsx
@@ -1,0 +1,48 @@
+import type { Dispatch, SetStateAction } from "react"
+
+import { NTButton } from "@/component/common/atom/nt-button"
+
+import { hasAOMImages } from "../aom.utils"
+
+import AOMImageList from "./aom-image-list"
+
+type AOMImageListPT = {
+	aomInfoArr: Array<{
+		imageUrl: string
+		imageId: number
+	}>
+	focusedIdx: number
+	setFocusedIdx: Dispatch<SetStateAction<number>>
+}
+
+export default function AOMImageListSection({
+	aomInfoArr,
+	focusedIdx,
+	setFocusedIdx,
+}: AOMImageListPT) {
+	return hasAOMImages(aomInfoArr) ? (
+		<div className="flex h-full w-full flex-col gap-y-2 border-l-2 border-l-Gray20 pl-8">
+			<p className="text-Title03 font-SemiBold">등록된 사진</p>
+			<p className="text-Title03 font-SemiBold text-PB100">{`${aomInfoArr.length}개`}</p>
+			<AOMImageList
+				aomInfoArr={aomInfoArr}
+				focusedIdx={focusedIdx}
+				setFocusedIdx={setFocusedIdx}
+			/>
+
+			<NTButton flexible={"fit"} size={"exSmall"}>
+				편집하기
+			</NTButton>
+		</div>
+	) : (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-y-3 rounded-3xl bg-White shadow-customGray80">
+			<p className="text-Title02 font-SemiBold text-Gray70">
+				등록된 이달의 아트가 없어요.
+			</p>
+			<p className="text-Body02 text-Gray50">
+				<span className="text-PB60">이달의 아트 등록</span> 버튼을 클릭해서
+				사진을 등록해 주세요.
+			</p>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom.utils.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom.utils.ts
@@ -1,0 +1,5 @@
+export const hasAOMImages = (
+	arr: Array<{ imageUrl: string; imageId: number }>,
+) => {
+	return arr.length !== 0
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/image-upload-box/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/image-upload-box/index.tsx
@@ -1,0 +1,49 @@
+import Image from "next/image"
+
+import { NTButton } from "@/component/common/atom/nt-button"
+import NTIcon from "@/component/common/nt-icon"
+import { cn } from "@/config/tailwind"
+
+import { hasAOMImages } from "../aom.utils"
+
+type IageUploadBoxPT = {
+	aomInfoArr: Array<{
+		imageUrl: string
+		imageId: number
+	}>
+	focusedIdx: number
+}
+
+export default function ImageUploadBox({
+	aomInfoArr,
+	focusedIdx,
+}: IageUploadBoxPT) {
+	return (
+		<div
+			className={cn(
+				"relative flex h-80 w-80 min-w-80 flex-col items-center justify-center gap-y-3 rounded-3xl border-[1.5px] bg-BGblue01 text-Gray70",
+				hasAOMImages(aomInfoArr) ? "border-transparent" : "border-PB50",
+			)}
+		>
+			{hasAOMImages(aomInfoArr) ? (
+				<Image
+					src={aomInfoArr[focusedIdx].imageUrl}
+					alt="이달의 아트"
+					fill
+					sizes="40vw"
+					priority
+					className="rounded-3xl"
+				/>
+			) : (
+				<>
+					<NTIcon icon="camera" className="h-9 w-9 text-Gray80" />
+					<p className="text-Body01 text-[18px] font-SemiBold">
+						사진을 등록하세요.
+					</p>
+					<p className="text-Body02"> 최대 10장까지 첨부 가능해요.</p>
+					<NTButton flexible={"fit"}>이달의 아트 등록</NTButton>
+				</>
+			)}
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/image-viewer-box/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/image-viewer-box/index.tsx
@@ -14,7 +14,7 @@ type IageUploadBoxPT = {
 	focusedIdx: number
 }
 
-export default function ImageUploadBox({
+export default function ImageViewerdBox({
 	aomInfoArr,
 	focusedIdx,
 }: IageUploadBoxPT) {

--- a/src/component/custom/manager/base/my-shop/home/aom/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/index.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react"
 
 import AOMImageList from "./aom-image-list-section"
-import ImageUploadBox from "./image-upload-box"
+import ImageViewerdBox from "./image-viewer-box"
 import { aomImageArr } from "./mock"
 
 export default function AOM() {
@@ -10,7 +10,7 @@ export default function AOM() {
 
 	return (
 		<div className="flex h-80 w-full items-center gap-x-5">
-			<ImageUploadBox aomInfoArr={aomImageArr} focusedIdx={foucsedIdx} />
+			<ImageViewerdBox aomInfoArr={aomImageArr} focusedIdx={foucsedIdx} />
 			<AOMImageList
 				aomInfoArr={aomImageArr}
 				focusedIdx={foucsedIdx}

--- a/src/component/custom/manager/base/my-shop/home/aom/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/index.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { useState } from "react"
+
+import AOMImageList from "./aom-image-list-section"
+import ImageUploadBox from "./image-upload-box"
+import { aomImageArr } from "./mock"
+
+export default function AOM() {
+	const [foucsedIdx, setFocusedIdx] = useState(0)
+
+	return (
+		<div className="flex h-80 w-full items-center gap-x-5">
+			<ImageUploadBox aomInfoArr={aomImageArr} focusedIdx={foucsedIdx} />
+			<AOMImageList
+				aomInfoArr={aomImageArr}
+				focusedIdx={foucsedIdx}
+				setFocusedIdx={setFocusedIdx}
+			/>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/mock.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/mock.ts
@@ -1,0 +1,12 @@
+export const aomImageArr = [
+	{ imageUrl: "https://loremflickr.com/320/320/nail", imageId: 1 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 2 },
+	{ imageUrl: "https://loremflickr.com/320/320/man", imageId: 3 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 4 },
+	{ imageUrl: "https://loremflickr.com/320/320/food", imageId: 5 },
+	{ imageUrl: "https://loremflickr.com/320/320/fire", imageId: 6 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 7 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 8 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 9 },
+	{ imageUrl: "https://loremflickr.com/320/320/nailart", imageId: 10 },
+]

--- a/src/component/custom/manager/base/my-shop/home/shop-information/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/shop-information/index.tsx
@@ -1,16 +1,24 @@
+import AOM from "../aom"
+
 import ReservationRequirements from "./reservation-requirements"
 import ShopDetails from "./shop-details"
 
 export default function ShopInformation() {
 	return (
-		<div className="flex min-h-[586px] w-full justify-between px-2 py-5">
-			<div className="flex flex-col gap-[20px]">
-				<p className="text-Title03">내 샵 정보</p>
-				<ShopDetails />
+		<div>
+			<div className="flex min-h-[586px] w-full justify-between px-2 py-5">
+				<div className="flex flex-col gap-[20px]">
+					<p className="text-Title03">내 샵 정보</p>
+					<ShopDetails />
+				</div>
+				<div className="flex flex-col gap-[20px]">
+					<p className="text-Title03">필수 예약 사항</p>
+					<ReservationRequirements />
+				</div>
 			</div>
-			<div className="flex flex-col gap-[20px]">
-				<p className="text-Title03">필수 예약 사항</p>
-				<ReservationRequirements />
+			<div className="flex flex-col gap-[20px] pb-20">
+				<p className="text-Title03">이달의 아트</p>
+				<AOM />
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## [Mock data추가 & 카메라 icon추가]
- [🤡 이달의아트 가상정보 추가 & 카메라 아이콘 추가](https://github.com/mobi-projects/nail-case-client/commit/770b8a7e29886ed47ab7ee2055e462fc8a66b1c3)

> BE측에게 요청한 데이터형태로 Mock데이터 추가했습니다.
또한 카메라 아이콘이 필요해서 NTIcon에 추가했습니다.

## [홈에서 보여질 이달의 아트 구성]
- [🎨 이달의 아트를 구성하는 ImageUploadBox , AOMImageList컴포넌트 추가](https://github.com/mobi-projects/nail-case-client/commit/f5748d5750d039664d1697dc6b22c7a75c15fa66)
- [🚚 imageUploadBox => imageViewerBox 이름수정](https://github.com/mobi-projects/nail-case-client/commit/f8fedb8d24f58e2af4d33e7f3e1caaf0cf0f7d84)

> 현재 ui가 준비되지 않아서 어떤 ui로 보여주면 좋을지 고민을 많이해봤습니다.
> woody님에게 의견받은대로 작업을 해봤는데요 

<div align="center">
<img width="393" alt="image" src="https://github.com/user-attachments/assets/49aebd60-6258-4309-a6ad-8d69d6c4124f">
</div>

>위의 ui를 참고해서 저희 프로젝트에 적용해봤습니다.
> 왼쪽에 확대된 이미지가 보여질 컴포넌트를 ImageViewrBox
> 오른쪽 이미지리스트가 보여질 컴포넌트를 AOMImageList로 구성했습니다.

## [ImageViewerBox]
- [🎨 ImageViewrBox](https://github.com/mobi-projects/nail-case-client/commit/f68b766bd843845b2d5731be5b48ea310b606ef8)

 **ImageViewerBox는 2가지의 역할을 수행합니다.**
 > 등록된 아트가 있을경우 => 확대된 사진을 보여줍니다.
 > 등록된 아트가 없는경우 => 아트를 등록할 버튼을 제공합니다.


## [AOMImageList]
- [🎨 AOMImageList](https://github.com/mobi-projects/nail-case-client/commit/df5b7528c7afdbf40640230dc95ab44e3313cec0)

> 기본5개의 image list가 보여지고 `>`아이콘 클릭시 다음 5개의 그룹이 보여집니다.
> overflow-hidden을 사용해 먼저 모든 이미지를 불러오고 , trasnformX를 통해 애니메이션으로 다음 그룹을 보여주도록 코드를 작성했습니다.
> animation을 통해 다음 image 그룹을 보여주도록 한 이유는 reflow 과정없이 repaint만 발생시키기 위함입니다.

## [결과물]

<div align="center">

### Case 등록된 아트가 없는 경우
<img width="970" alt="image" src="https://github.com/user-attachments/assets/b89ca14f-dc16-446d-a4e5-fbbbc06bdae2">

### Case 등록된 아트가 있는 경우


https://github.com/user-attachments/assets/76faf8d6-1dbe-4d51-a059-266ba2d98b37



</div>


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
