### PR TITLE
feat : 판매자 홈 AOM fetching api , hook 생성 & 로딩 , 에러 ui추가

### DIFF
--- a/src/component/custom/manager/base/my-shop/home/aom/aom-error/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-error/index.tsx
@@ -1,0 +1,9 @@
+export default function AOMError() {
+	return (
+		<div className="flex h-80 w-full items-center justify-center rounded-3xl border-[3px] border-Gray20">
+			<div className="text-Title01 text-PB100">
+				죄송합니다. 네트워크 문제로 이미지를 불러오지 못했습니다.
+			</div>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-list.util.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/aom-image-list.util.ts
@@ -1,10 +1,6 @@
-export const isArrayLengthOver = (
-	imageArr: Array<{
-		imageUrl: string
-		imageId: number
-	}>,
-	threshold: number,
-) => {
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
+
+export const isArrayLengthOver = (imageArr: TResAOM, threshold: number) => {
 	return imageArr.length > threshold
 }
 

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-image-list/index.tsx
@@ -4,6 +4,7 @@ import type { Dispatch, SetStateAction } from "react"
 
 import NTIcon from "@/component/common/nt-icon"
 import { cn } from "@/config/tailwind"
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
 
 import {
 	getSlideCss,
@@ -13,10 +14,7 @@ import {
 import AOMImageSingle from "./aom-image-single"
 
 type AOMImageSectionPT = {
-	aomInfoArr: Array<{
-		imageUrl: string
-		imageId: number
-	}>
+	aomInfoArr: TResAOM
 	focusedIdx: number
 	setFocusedIdx: Dispatch<SetStateAction<number>>
 }

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/aom-manage-modal.util.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/aom-manage-modal.util.ts
@@ -1,12 +1,9 @@
-export const isAOMImageArrayFull = (
-	arr: Array<{ imageUrl: string; imageId: number }>,
-	treshold: number,
-) => {
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
+
+export const isAOMImageArrayFull = (arr: TResAOM, treshold: number) => {
 	return arr.length === treshold
 }
-export const isAOMImageArryEmpty = (
-	arr: Array<{ imageUrl: string; imageId: number }>,
-) => {
+export const isAOMImageArryEmpty = (arr: TResAOM) => {
 	return arr.length === 0
 }
 

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/edit-aom/aom-precautions/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/edit-aom/aom-precautions/index.tsx
@@ -4,27 +4,27 @@ export default function AOMPrecautions() {
 	return (
 		<div className="flex flex-col gap-y-2">
 			<p className="pt-5 text-Title03 font-SemiBold"> 유의 사항 </p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" />
 				<NTIcon
 					icon="delete"
 					className="mr-1 h-4 w-4 rounded-full border-White bg-Gray70 text-PY80"
 				/>
 				아이콘을 클릭하면 등록된 사진을 삭제할 수 있어요.
-			</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			</div>
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" />
 				<NTIcon icon="camera" className="h-5 w-5 pr-1 text-PB100" />
 				아이콘을 클릭하면 사진을 등록할 수 있어요.
-			</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			</div>
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" /> 사진은 최대
 				<span className="px-1 text-PB100"> 10장</span> 까지 등록 가능해요.
-			</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			</div>
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" /> 사진을 성공적으로 등록하셨다면
 				등록 완료 버튼을 눌러 사진을 업로드 해주세요.
-			</p>
+			</div>
 		</div>
 	)
 }

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/register-guide/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/aom-manage-modal/register-guide/index.tsx
@@ -21,34 +21,34 @@ export function RegisterGuide({ isGuideVisible }: RegisterGuidePT) {
 			<p className="text-Title02 font-SemiBold">
 				이달의 아트 등록전에 꼭 확인해 주세요!
 			</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" />
 				<span className="text-base font-SemiBold text-PB100">NewTips</span>
 				에서는 사장님들의 편리한 예약을 도와드리기 위해 이달의 아트를 등록 할 때
 				<span className="px-1 text-red-500"> 주의</span> 해야할 점이 있어요.
-			</p>
+			</div>
 			<p className="text-Title02 font-SemiBold">등록 방법</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" />
 				사진은 최대 <span className="px-1 text-PB100"> 10장</span> 까지 등록
 				가능해요.
-			</p>
-			<p className="flex items-center text-Caption01 text-Gray70">
+			</div>
+			<div className="flex items-center text-Caption01 text-Gray70">
 				<NTIcon icon="dot" className="h-5 w-5" />
 				편리한 예약을 위해 네일별로
 				<span className="px-1 text-PB100">한장</span>씩 사진을 등록해 주세요.
-			</p>
+			</div>
 			<div className="flex items-center justify-evenly text-Headline01">
 				<div className="flex flex-col items-center justify-center gap-y-1">
-					<p className="flex items-center">
+					<div className="flex items-center">
 						올바른 예시
 						<NTIcon icon="check" className="h-7 w-7 pb-1 text-green-600" />
-					</p>
+					</div>
 					<Image
 						alt="예시 사진"
 						src={"https://loremflickr.com/320/320/nail"}
 						width={250}
-						height={120}
+						height={250}
 					/>
 					<p className="flex flex-wrap pt-4 text-Caption02 text-Gray70">
 						고객님들의 정확한 사진 선택을 위해
@@ -56,15 +56,15 @@ export function RegisterGuide({ isGuideVisible }: RegisterGuidePT) {
 					</p>
 				</div>
 				<div className="flex flex-col items-center justify-center gap-y-1">
-					<p className="flex items-center">
+					<div className="flex items-center">
 						잘못된 예시
 						<NTIcon icon="delete" className="h-7 w-7 pb-1 text-red-500" />
-					</p>
+					</div>
 					<Image
 						alt="예시 사진"
 						src={"https://loremflickr.com/320/320/nail"}
 						width={250}
-						height={120}
+						height={250}
 					/>
 					<p className="flex flex-wrap pt-4 text-Caption02 text-Gray70">
 						모든 아트가 포함된 한장의 사진으로 올리는 것은

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-image-list-section/index.tsx
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react"
 
 import { NTButton } from "@/component/common/atom/nt-button"
 import { useModal } from "@/component/common/nt-modal/nt-modal.context"
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
 
 import { hasAOMImages } from "../aom.utils"
 
@@ -9,10 +10,7 @@ import AOMImageList from "./aom-image-list"
 import AOMManageModal from "./aom-manage-modal"
 
 type AOMImageListPT = {
-	aomInfoArr: Array<{
-		imageUrl: string
-		imageId: number
-	}>
+	aomInfoArr: TResAOM
 	focusedIdx: number
 	setFocusedIdx: Dispatch<SetStateAction<number>>
 }

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-skelton/aom-image-single-skeloton/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-skelton/aom-image-single-skeloton/index.tsx
@@ -1,0 +1,5 @@
+export default function AOMImageSingleSkelotn() {
+	return (
+		<div className="h-24 w-24 transform animate-pulse rounded-[26px] bg-Gray20" />
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom-skelton/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom-skelton/index.tsx
@@ -1,0 +1,20 @@
+import AOMImageSingleSkelotn from "./aom-image-single-skeloton"
+
+export default function AOMSkelton() {
+	return (
+		<div className="flex h-80 w-full items-center gap-x-5">
+			<div className="h-80 w-80 min-w-80 transform animate-pulse rounded-3xl bg-Gray20 duration-700" />
+			<div className="flex h-full w-full flex-col justify-evenly gap-y-2 border-l-2 border-l-Gray20 pl-8">
+				<div className="h-6 w-1/4 transform animate-pulse rounded-xl bg-Gray20" />
+				<div className="h-6 w-1/4 transform animate-pulse rounded-xl bg-Gray20" />
+				<div className="flex gap-x-3 pl-8">
+					{Array.from({ length: 5 }, (_, idx) => (
+						<AOMImageSingleSkelotn key={idx} />
+					))}
+				</div>
+
+				<div className="h-12 w-20 transform animate-pulse rounded-xl bg-Gray20" />
+			</div>
+		</div>
+	)
+}

--- a/src/component/custom/manager/base/my-shop/home/aom/aom.utils.ts
+++ b/src/component/custom/manager/base/my-shop/home/aom/aom.utils.ts
@@ -1,5 +1,5 @@
-export const hasAOMImages = (
-	arr: Array<{ imageUrl: string; imageId: number }>,
-) => {
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
+
+export const hasAOMImages = (arr: TResAOM) => {
 	return arr.length !== 0
 }

--- a/src/component/custom/manager/base/my-shop/home/aom/image-viewer-box/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/image-viewer-box/index.tsx
@@ -4,15 +4,13 @@ import { NTButton } from "@/component/common/atom/nt-button"
 import NTIcon from "@/component/common/nt-icon"
 import { useModal } from "@/component/common/nt-modal/nt-modal.context"
 import { cn } from "@/config/tailwind"
+import type { TResAOM } from "@/util/api-v2/list-monthly-art"
 
 import AOMHandleModal from "../aom-image-list-section/aom-manage-modal"
 import { hasAOMImages } from "../aom.utils"
 
 type IageUploadBoxPT = {
-	aomInfoArr: Array<{
-		imageUrl: string
-		imageId: number
-	}>
+	aomInfoArr: TResAOM
 	focusedIdx: number
 }
 

--- a/src/component/custom/manager/base/my-shop/home/aom/index.tsx
+++ b/src/component/custom/manager/base/my-shop/home/aom/index.tsx
@@ -1,18 +1,24 @@
 "use client"
 import { useState } from "react"
 
+import { useGetMonthlyArtList } from "@/hook/use-aom"
+import { isUndefined } from "@/util/common/type-guard"
+
+import AOMError from "./aom-error"
 import AOMImageList from "./aom-image-list-section"
+import AOMSkelton from "./aom-skelton"
 import ImageViewerdBox from "./image-viewer-box"
-import { aomImageArr } from "./mock"
 
 export default function AOM() {
 	const [foucsedIdx, setFocusedIdx] = useState(0)
-
+	const { data: AOMData, isLoading, isError } = useGetMonthlyArtList(1)
+	if (isLoading) return <AOMSkelton />
+	if (isError || isUndefined(AOMData)) return <AOMError />
 	return (
 		<div className="flex h-80 w-full items-center gap-x-5">
-			<ImageViewerdBox aomInfoArr={aomImageArr} focusedIdx={foucsedIdx} />
+			<ImageViewerdBox aomInfoArr={AOMData.dataList} focusedIdx={foucsedIdx} />
 			<AOMImageList
-				aomInfoArr={aomImageArr}
+				aomInfoArr={AOMData.dataList}
 				focusedIdx={foucsedIdx}
 				setFocusedIdx={setFocusedIdx}
 			/>

--- a/src/hook/use-aom.ts
+++ b/src/hook/use-aom.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { QUERY_MONTHLY_ART_ARR } from "@/constant"
+import { getMonthlyArtList } from "@/util/api-v2/list-monthly-art"
+/** AOM 목록조회 */
+export const useGetMonthlyArtList = (shopId: number) =>
+	useQuery({
+		queryKey: [QUERY_MONTHLY_ART_ARR, shopId],
+		queryFn: () => getMonthlyArtList(shopId),
+	})

--- a/src/util/api-v2/list-monthly-art.ts
+++ b/src/util/api-v2/list-monthly-art.ts
@@ -1,0 +1,16 @@
+import { axiosInstance } from "@/config/axios"
+import type { TResponseData } from "@/type/response"
+
+/** [GET] 판매자 등록 이달의 아트 조회 API 요청 */
+export const getMonthlyArtList = async (
+	shopId: number,
+): Promise<TResponseData<TResAOM, "dataList">> => {
+	const response = await axiosInstance().get(
+		`/shops/${shopId}/monthly-art/images`,
+	)
+	return response.data
+}
+
+export type TResAOM = Array<AOMImage>
+
+export type AOMImage = { imageUrl: string; imageId: number }


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->
sub-issues:
- [NAILCASE-414](https://nailcase.atlassian.net/browse/NAILCASE-414)

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## [api 작성 & useQuery hook 생성]

- [✨ AOM목록조회 api 함수 & 훅 생성](https://github.com/mobi-projects/nail-case-client/commit/ef11035c729ef9377b6716e781492844e9100f52)

### 패칭 방식에 대해서

> 해당 pr에서 작성한 api와 hook은 간단한 코드라서 크게 문제되진 않을것 같은데 nextJs에서 react-query사용 방식에 대해 논의해보고 싶습니다.

> 현재 작업한 `판매자 홈` 에서 shop정보에 대한 fetching은 서버패칭을 하도록 설정되어 있습니다.
여기서 해당 pr에서 작업한 aom데이터를 fetching하는 코드 또한 서버패칭을 해야하냐?? 라는 부분을 고민해봤는데요

**서버 패칭을 하는 목적은 2가지가 있다고 생각되는데요 (SEO최적화 & 빠른 ui제공)**
>aom이미지가 SEO최적화를 위해 사용되냐?? ==> 제 생각은 X입니다.
사용자에게 빠르게 화면에 나타난 ui를 봐야하냐? ===> 제 생각은 빠른ui 제공이라면 좋지않을까?입니다.

**제 생각은 이렇습니다.**
> 빠른 ui를 보여주는것 물론 좋습니다.
하지만.. 최적화를 위한것이 아니라면 image데이터의 경우 서버패칭으로 불러온다면 서버측에 부담이 되는 작업이라고 생각 됩니다. Image데이터를 패칭하는 경우이기에 클라이언트 에서 호출하도록 작업을 진행했습니다.


## [ui 분기처리]
- [🎨 클라이언트 패칭에서 발생할 수 있는 loading, error ui 추가](https://github.com/mobi-projects/nail-case-client/commit/e1eec6497d2f1b3102cd8bc7466507b8a5355969)

**클라이언트 패칭을 하기때문에 loading ui , error ui 추가했습니다.**

<div align="center">

### loading ui


https://github.com/user-attachments/assets/2efde561-4d25-4cf6-a055-93e4a54af312


### error ui


https://github.com/user-attachments/assets/b80b542c-008f-46b0-a914-cc91b5036155



</div>

## [오류 해결]
- [🐛 AOM modal 오류코드 수정](https://github.com/mobi-projects/nail-case-client/commit/f359c3a297f3697f3b497e047b69a98477d281d8)

> 죄송합니다... 제가 작성했던 코드에서 동작에는 문제없지만 react-rule을 어긴 코드를 작성했었습니다.

```tsx
<p> 
  <div/>   // p태그의 자식으로 div태그를 넣은부분이 있었습니다.. react-rule에 어긋나는 코드라고 합니다.
</p>
```

> image관련한 error도 있었습니다.

```tsx
  <Image
	alt="예시 사진"
        src={"https://loremflickr.com/320/320/nail"} 
	width={250}
	height={120}
```
위 코드에서 보시면 image의 사이즈는 320 / 320 으로 1 : 1 비율을 유지해서 받아옵니다.
저는  w-250- h-120 으로 약 2:1 의 비율로 설정을 했는데요..  이때 원본 비율과 다르기때문에 비율을 자동으로 조절하려면 auto속성을 추가해라 라는 메세지가 떳습니다.

사실저는 1:1의 비율로 설정하길 바랬는데 따라서 height = 250으로 수정해서 경고 메세지를 제거했습니다.

## [그 외]
- [🏷️ api에 정의된 tpye으로 수정](https://github.com/mobi-projects/nail-case-client/commit/65b3b5e58314f29bd09c75aa075e08028fc447cd)

> api 파일에 작성된 type으로 각 파일에 type을 업데이트 했습니다.


<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [x] Main 브랜치 Pull 받기
- [x] Issue 번호 설정 확인
- [x] Label 확인
- [x] Assignees 설정 확인
- [x] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```


[NAILCASE-414]: https://nailcase.atlassian.net/browse/NAILCASE-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ