### PR TITLE
design : 예약관리 페이지 반응형 사이드바 추가

### DIFF
--- a/src/app/manager/(with-layout)/[shopId]/reservations/[status]/[page]/page.tsx
+++ b/src/app/manager/(with-layout)/[shopId]/reservations/[status]/[page]/page.tsx
@@ -18,7 +18,7 @@ export default function Reservations({ params }: ReservationsPT) {
 	return (
 		<>
 			<ReservationsHeader status={status} />
-			<div className="mt-6 grid w-full grid-cols-[1.2fr_1fr] gap-x-6">
+			<div className="mt-6 grid w-full grid-cols-[1.2fr_1fr] gap-x-6 max-lg:flex max-lg:flex-col max-lg:gap-y-5 max-lg:pl-3 max-lg:pr-6">
 				<div>
 					<p className="pb-4 text-Title01 font-SemiBold text-Gray60">
 						{translateStatus(status)}

--- a/src/component/custom/manager/(with-layout)/reservations/reservations-header/catagory-box/index.tsx
+++ b/src/component/custom/manager/(with-layout)/reservations/reservations-header/catagory-box/index.tsx
@@ -76,7 +76,7 @@ export default function CategoryBox({ status, isClicked }: CategoryBoxPT) {
 	)
 }
 
-const getLowerCasedStatus = (
+export const getLowerCasedStatus = (
 	status: TStatusExcludeCanceled,
 ): "rejected" | "completed" | "pending" | "confirmed" => {
 	const lowerCaseStatus = status.toLowerCase() as

--- a/src/component/custom/manager/(with-layout)/reservations/reservations-header/index.tsx
+++ b/src/component/custom/manager/(with-layout)/reservations/reservations-header/index.tsx
@@ -2,6 +2,7 @@ import { STATUS_WITHOUT_CANCELED_ARR } from "../reservations.constant"
 import type { TStatusExcludeCanceled } from "../reservations.type"
 
 import CategoryBox from "./catagory-box"
+import MobileReservationSideBar from "./mobile-reservation-side-bar"
 
 type ReservationsHeaderPT = {
 	status: TStatusExcludeCanceled
@@ -11,14 +12,17 @@ export default function ReservationsHeader({
 	status: curStatus,
 }: ReservationsHeaderPT) {
 	return (
-		<div className="mt-10 flex w-full items-center justify-between pb-8">
-			{STATUS_WITHOUT_CANCELED_ARR.map((status, idx) => (
-				<CategoryBox
-					status={status}
-					key={status}
-					isClicked={STATUS_WITHOUT_CANCELED_ARR[idx] === curStatus}
-				/>
-			))}
+		<div className="h-full w-full">
+			<div className="mt-10 flex w-full items-center justify-between pb-8 max-lg:hidden">
+				{STATUS_WITHOUT_CANCELED_ARR.map((status, idx) => (
+					<CategoryBox
+						status={status}
+						key={status}
+						isClicked={STATUS_WITHOUT_CANCELED_ARR[idx] === curStatus}
+					/>
+				))}
+			</div>
+			<MobileReservationSideBar />
 		</div>
 	)
 }

--- a/src/component/custom/manager/(with-layout)/reservations/reservations-header/mobile-reservation-side-bar/index.tsx
+++ b/src/component/custom/manager/(with-layout)/reservations/reservations-header/mobile-reservation-side-bar/index.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react"
+
+import NTIcon from "@/component/common/nt-icon"
+import { cn } from "@/config/tailwind"
+
+import { STATUS_WITHOUT_CANCELED_ARR } from "../../reservations.constant"
+
+import MoblieCategoryItem from "./mobile-category-item"
+
+export default function MobileReservationSideBar() {
+	const [isOpen, setIsOpen] = useState(false)
+
+	return (
+		<div className="fixed bottom-0 right-0 z-40 max-lg:flex">
+			{/* 사이드바 아이콘 */}
+			<div
+				className={cn(
+					"rounded-l-xl bg-Gray20 shadow-customGray80 transition-all",
+					isOpen ? "translate-x-0" : "translate-x-full",
+				)}
+				tabIndex={-1}
+				onBlur={() => setIsOpen(false)}
+			>
+				<NTIcon
+					icon="expandRight"
+					className={cn(
+						"h-6 w-6 cursor-pointer transition-transform",
+						isOpen ? "-rotate-180" : "rotate-0",
+					)}
+					onClick={() => setIsOpen((prev) => !prev)}
+				/>
+			</div>
+
+			{/* 슬라이드 애니메이션과 함께 사이드바 내용 */}
+			<div
+				className={cn(
+					"w-[14rem] transform bg-White shadow-customGray80 transition-all",
+					isOpen
+						? "translate-x-0 opacity-100"
+						: "w-6 translate-x-full opacity-0",
+				)}
+			>
+				<p className="flex h-10 items-center border-b border-Gray20 bg-Gray10 px-5 text-Title02 font-SemiBold text-Black max-md:text-[18px]">
+					예약 관리 메뉴
+				</p>
+				<div className="flex flex-col">
+					{STATUS_WITHOUT_CANCELED_ARR.map((status) => (
+						<MoblieCategoryItem
+							status={status}
+							key={status}
+							setIsOpen={setIsOpen}
+						/>
+					))}
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/src/component/custom/manager/(with-layout)/reservations/reservations-header/mobile-reservation-side-bar/mobile-category-item/index.tsx
+++ b/src/component/custom/manager/(with-layout)/reservations/reservations-header/mobile-reservation-side-bar/mobile-category-item/index.tsx
@@ -1,0 +1,65 @@
+import { cva } from "class-variance-authority"
+import { usePathname, useRouter } from "next/navigation"
+import type { Dispatch, SetStateAction } from "react"
+
+import NTIcon from "@/component/common/nt-icon"
+import { cn } from "@/config/tailwind"
+import { MANAGER_BASE, MANAGER_RESERVATIONS } from "@/constant/routing-path"
+
+import { translateStatus } from "../../../reservations,util"
+import type { TStatusExcludeCanceled } from "../../../reservations.type"
+import { getLowerCasedStatus } from "../../catagory-box"
+
+type MoblieCatagoryItemPT = {
+	status: TStatusExcludeCanceled
+	setIsOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export default function MoblieCategoryItem({
+	setIsOpen,
+	status,
+}: MoblieCatagoryItemPT) {
+	const icon = getLowerCasedStatus(status)
+	const router = useRouter()
+	const pathName = usePathname()
+	const shopId = pathName.split("/")[2]
+	return (
+		<div
+			className={cn(
+				"flex h-24 w-full items-center gap-x-4 border-b border-b-Gray20 px-4 transition-all",
+			)}
+			onClick={() => {
+				router.push(
+					`${MANAGER_BASE}/${shopId}${MANAGER_RESERVATIONS}/${status}/1`,
+				)
+				setIsOpen(false)
+			}}
+		>
+			<NTIcon icon={icon} className={cn(iconVarinats({ textColor: status }))} />
+			<div className={cn(titleVarinats({ textColor: status }))}>
+				{translateStatus(status)}
+			</div>
+		</div>
+	)
+}
+
+const titleVarinats = cva("text-Body01 font-Bold transition-all ", {
+	variants: {
+		textColor: {
+			PENDING: "text-PB70",
+			REJECTED: "text-red-300",
+			CONFIRMED: "text-PURPLE50",
+			COMPLETED: "text-GREEN50",
+		},
+	},
+})
+const iconVarinats = cva("h-8 w-8 transition-all", {
+	variants: {
+		textColor: {
+			PENDING: "text-PB70",
+			REJECTED: "text-red-300",
+			CONFIRMED: "text-PURPLE50",
+			COMPLETED: "text-GREEN50",
+		},
+	},
+})


### PR DESCRIPTION
## 🔥 Issues

<!-- [여기서부터 주석]

    - 관련된 issue 티켓과 링크를 작성해주세요.

      ex)
        * issue: [NAILCASE-100001](https://nailcase.atlassian.net/browse/NAILCASE-100001)
        sub-issues:
          - [NAILCASE-100002](https://nailcase.atlassian.net/browse/NAILCASE-100002)
          - [NAILCASE-100003](https://nailcase.atlassian.net/browse/NAILCASE-100003)


[여기까지 주석] -->

<br/>
<br/>

## 🎯 작업 내용

<!-- [여기서부터 주석]

    - 👋🏼 이 주석 영역 아래, "작업 내용" 항목 을 다음과 같은 형식으로 작성해주세요. (이미지/동영상을 추가하면 엄청 좋습니다. 👍)

        예시)
        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

        - [commit 이름](commit url)
          - 이 commit 에서는 이러이러한 작업을 했습니다.
          - 이러이러한 내용을 꼭 숙지해주세요.

    - "이건 알겠지?" 라고 생각되는 것조차 적어야합니다.!

    - publish 작업을 했거나 jsx 요소를 건드린 경우, 무조건 이미지를 첨부해주세요.

[여기까지 주석] -->

## 반응형 사이드바 추가
- [🎨 예약관리 페이지 반응형 사이드바 추가](https://github.com/mobi-projects/nail-case-client/commit/d541fcbbf2012013fe9b42d72dac34ad8d41ba6f)

예약관리 페이지에서는 반응형을 사이드바로 구현했습니다.


https://github.com/user-attachments/assets/de662835-871e-4586-bc0d-af72ca4b7be1



<br/>
<br/>

## ✅ 체크 리스트

<!-- [여기서부터 주석]

    👋🏼 이 주석 영역 아래, checklist 꼭 확인하고 표식을 남겨주세요.

    체크하는 방법)
    "[" 랑 "]" 사이에 공백없이 x 표시해주기!!!

    올바른 예)
    [x]

    잘못된 예)
    [ x]
    [x ]
    [ x ]

[여기까지 주석] -->

- [ ] Main 브랜치 Pull 받기
- [ ] Issue 번호 설정 확인
- [ ] Label 확인
- [ ] Assignees 설정 확인
- [ ] Reviewers 설정 확인

<br/>
<br/>

---

#### 🙏 꼭 리뷰 남겨주세요.!!

- 아래 양식에 맞게 리뷰 부탁드립니다..!!
- 수정을 요구하는 게 아니라면, "Description" 을 꼭 남기지 않아도 좋습니다. 👍

```text
# Request Level

<!--
  - [x] "🚨 꼭 수정해주세요.!"
-->

<!--
  - [x] "🚧 재고해주시길.."
-->

<!--
  - [x] "✅ LGTM"
-->

# Description

```
